### PR TITLE
ci: fix duplicate workflow runs and gate Docker by tag

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -5,9 +5,13 @@ name: build-test-push
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    tags: ['v*']
   pull_request:
-    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -81,6 +85,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
     - name: Login to DockerHub
+      if: github.ref_type == 'tag'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -91,7 +96,7 @@ jobs:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64
-        push: true
+        push: ${{ github.ref_type == 'tag' }}
         tags: ${{ secrets.DOCKERHUB_USERNAME }}/apacheds-ad:latest
         cache-from: ${{ secrets.DOCKERHUB_USERNAME }}/apacheds-ad-cache
         cache-to: ${{ secrets.DOCKERHUB_USERNAME }}/apacheds-ad-cache


### PR DESCRIPTION
## Summary
- Restrict push trigger to default branch + tags
- Add concurrency group to cancel superseded runs
- Gate Docker push by tag (push only on v* tags)
- Gate Docker login by tag

## Test plan
- [ ] Verify PRs trigger CI once (not twice)
- [ ] Verify Docker push only happens on tag push