### PR TITLE
docs: pin upload-artifact at v4 rationale (act blob-protocol incompat)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ A separate [`cleanup-runs.yml`](.github/workflows/cleanup-runs.yml) prunes old w
 
 **Security stack: OWASP dependency-check + Trivy only — do NOT propose re-adding Snyk.** Maven dep CVEs are covered by OWASP DC (`cve-check` job, weekly cron + tag pushes, NVD-backed). Source/config vulns + secrets are covered by Trivy filesystem scan (`build` job, informational). Built-image vulns are covered by Trivy image scan (`docker` job, CRITICAL/HIGH blocking gate). The Snyk GitHub App was intentionally removed — it was account-level (read access to source), gated nothing, and 100% overlapped OWASP DC on Maven deps. If a future analysis suggests adding Snyk, decline with this reasoning.
 
+**`actions/upload-artifact` pinned at v4.6.2 — do NOT bump to v5/v6/v7 until `nektos/act` ships v4 blob-storage protocol support.** v5.0.0 bumped `@actions/artifact` to v4, which speaks a new blob-upload protocol that `act`'s built-in `--artifact-server-path` does not implement. Empirically verified 2026-05-31: bumping to v6.0.0 makes `make ci-run` fail in the `Upload shaded JAR` step with `Error unauthorized`, breaking the local CI mirror. v4.6.2 still works on real GitHub Actions and on `act`; GitHub annotates the runs with a Node 20 deprecation notice (deadline 2026-06-16 — at which point Node 24 is forced on by default; v4 will still run, just on the new default runtime). Revisit when act adds v4 protocol support OR when a v4.7+ tag ships Node 24 support without the protocol bump.
+
 ### Required secrets
 
 `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Settings → Secrets and variables → Actions; used only by the `docker` job). `NVD_API_KEY` is OPTIONAL — without it the `cve-check` job still works but NVD lookups are rate-limited. `GITHUB_TOKEN` is auto-provisioned.


### PR DESCRIPTION
## Summary

Document the rationale for pinning `actions/upload-artifact` at v4.6.2 despite the Node 20 deprecation annotation (deadline 2026-06-16).

## Why

Post-merge CI on master (commit \`513c6dd\`) surfaced the Node 20 deprecation warning. Investigated whether to bump:

- **v5.0.0** bumped \`@actions/artifact\` to v4 — a new blob-upload protocol.
- **v6.0.0** defaults to Node 24 runtime; same v4 protocol.
- **v7.0.0** adds ESM + direct uploads; still v4 protocol.

Empirically tested v6.0.0 against \`make ci-run\` (\`act push\`). Result:

\`\`\`
[CI/build  ]   | Beginning upload of artifact content to blob storage
time=\"...\" level=error msg=\"Error unauthorized\"
[CI/build  ]   ❌  Failure - Main Upload shaded JAR
\`\`\`

\`nektos/act\`'s built-in \`--artifact-server-path\` does not implement the v4 blob protocol. Bumping breaks the local CI mirror.

**Trade-off accepted**: v4.6.2 still runs cleanly on real GitHub Actions and under \`act\`. The Node 20 deprecation only forces Node 24 as the default runtime starting 2026-06-16; v4 continues to run on Node 24 — it's a runtime nudge, not a removal. Local CI parity (\`make ci-run\`) is the higher-value invariant.

## Test plan

- [x] \`make ci\` BUILD SUCCESS (no workflow change to test runtime)
- [x] No code changes — CLAUDE.md doc note only