### PR TITLE
feat: ApacheDS M24 -> AM27 + Java 21 target + StartTlsTest reactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versioning follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The fork inherits the upstream Java code from
+[intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server); only
+fork-owned changes (Docker pipeline, Makefile, hardened CI, Renovate config,
+and dependency / source migrations driven by the fork) are recorded below.
+
+## [Unreleased]
+
+### Added
+
+- **ApacheDS 2.0.0.AM27 migration** (real Major migration, formerly deferred).
+  AM27 removes M24's EhCache-backed `CacheService`, drops
+  `Dn.apply(SchemaManager)`, tightens `AbstractLdifPartition.doInit()` to
+  `throws LdapException`, and asserts a `PartitionWriteTxn` on the
+  `OperationContext` for every `partition.add()` call. The migration replaces
+  the EhCache block in `InMemoryDirectoryServiceFactory` (AM27's
+  `DefaultDnFactory` uses an internal Caffeine cache), rebuilds the suffix DN
+  via `new Dn(schemaManager, suffixDn)`, and wraps the schema-load loop in
+  `InMemorySchemaPartition.doInit()` with `beginWriteTransaction()` /
+  `commit()` / `abort()`. AM27 also removes M24's `CoreKeyStoreSpi` fallback,
+  so `LdapServer` now generates a self-signed EC keystore via
+  `CertificateUtil.createTempKeyStore()` when no `--ssl-keystore-file` is
+  supplied — preserving the "just works without config" behavior for tests
+  and dev. See [CLAUDE.md Upgrade Backlog cheat-sheet](CLAUDE.md#am27-migration-cheat-sheet-recorded-so-a-future-bump-doesnt-redo-the-research)
+  for the full breaking-change list.
+- **`StartTlsTest` reactivated.** AM27's MINA TLS stack supports TLSv1.3 +
+  `TLS_AES_128_GCM_SHA256`; the `@Disabled` marker that had blocked this test
+  since the M24 / MINA-pre-TLSv1.3 era was removed. Test suite is now 8/8.
+
+### Changed
+
+- **`maven.compiler.source` / `maven.compiler.target` bumped from `1.8` to
+  `21`.** AM27 still ships bytecode 52 (Java 8), but a dep's bytecode floor
+  does not constrain the consumer's target — the application now compiles to
+  bytecode 65 (Java 21), matching the `eclipse-temurin:21-jre` runtime in the
+  Dockerfile. Eliminates the `[debug target 1.8] / source value 8 is obsolete`
+  warnings on every build.
+- **Shaded JAR size: ~19.94 MB → ~16 MB.** AM27's removal of the EhCache
+  transitive (~9 MB) drops the JAR substantially.
+
+### Documented
+
+- **`actions/upload-artifact` pinned at v4.6.2** until `nektos/act` ships
+  support for the v4 blob-storage protocol introduced in upload-artifact
+  v5.0.0. v5/v6/v7 all break `make ci-run` with `Error unauthorized` against
+  act's `--artifact-server-path`. Node 20 deprecation deadline 2026-06-16 is a
+  default-runtime nudge, not a removal; v4 continues to run on Node 24.
+
+## [1.1.0-modernization] — Sync with upstream + modernize toolchain, CI, Dockerfile
+
+Two consolidated PRs (#6 and #7) on 2026-05-30 / 2026-05-31. Squash commits
+[513c6dd](https://github.com/AndriyKalashnykov/ldap-server/commit/513c6dd) and
+[b0f1833](https://github.com/AndriyKalashnykov/ldap-server/commit/b0f1833).
+
+### Added
+
+- **Maven shade `<artifactSet><excludes>`** for `junit:junit` and
+  `org.hamcrest:hamcrest-core` — apacheds-all's M24 POM leaked these
+  test-scope deps into compile scope; the production JAR no longer contains
+  them.
+- **Dockerfile base images digest-pinned**:
+  `maven:3.9-eclipse-temurin-21@sha256:1bb51c5e…` and
+  `eclipse-temurin:21-jre@sha256:010e0a06…`. Both digests resolved from the
+  multi-arch OCI index via the registry HEAD; Renovate's `dockerfile`
+  manager maintains them in-place on tag moves.
+- **CLAUDE.md note pinning OWASP DC + Trivy as the canonical security stack**;
+  Snyk GitHub App was removed (account-level read access, 100% overlap with
+  OWASP DC).
+
+### Changed
+
+- **JUnit 4 → JUnit 5 Jupiter** via `org.junit:junit-bom:6.1.0` across 4 test
+  files. `@RunWith(Parameterized.class)` → `@ParameterizedTest` +
+  `@MethodSource`, `@Before` / `@After` → `@BeforeEach` / `@AfterEach`,
+  `@Ignore` → `@Disabled`. Surefire's built-in JUnit 5 provider handles the
+  BOM — no `junit-platform-launcher` needed.
+- **SLF4J 1.7.36 → 2.0.18** (ServiceLoader binding).
+- **JCommander 1.32 → 1.82.** `ExtCommander` rewritten to register a custom
+  `IUsageFormatter` (1.82 moved usage rendering out of `JCommander.usage(...)`);
+  `CLIArguments.ldifFiles` lost its `final` modifier (1.82 rejects `final`
+  `@Parameter` fields).
+- **Maven plugin bumps**: shade 3.6.2, compiler 3.15.0, exec 3.6.3,
+  bundle 6.0.2. OWASP dependency-check Maven plugin pinned at 12.2.2 in
+  `<pluginManagement>` (invoked via fully-qualified coordinate; no version
+  argument on the CLI).
+- **mise toolchain**: Java `temurin-21.0.11+10.0.LTS`, Maven `3.9.16`.
+- **GitHub Actions majors** (all SHA-pinned, all Node 24 runtime drop-ins):
+  - `actions/checkout` v5 → v6.0.2
+  - `actions/cache` v4.3.0 → v5.0.5
+  - `actions/download-artifact` v4.3.0 → v8.0.1
+  - `jdx/mise-action` v3.6.0 → v4.0.1
+  - `dorny/paths-filter` v3.0.2 → v4.0.1
+  - `docker/setup-qemu-action` v3.6.0 → v4.1.0
+  - `docker/setup-buildx-action` v3.11.1 → v4.1.0
+  - `docker/metadata-action` v5.8.0 → v6.1.0
+  - `docker/login-action` v3.5.0 → v4.2.0
+  - `docker/build-push-action` v6.18.0 → v7.2.0
+  - `softprops/action-gh-release` v2.2.2 → v3.0.0
+
+### Removed
+
+- **`src/main/resources/users.ldif`** — 424 lines, fork-preserved for 12
+  years, zero code paths referenced it. Bundled `ldap-example.ldif` is the
+  default seed data.
+- **`scripts/*.sh`** (`build.sh`, `run.sh`, `push.sh`, `local-run.sh`,
+  `set-env.sh`) — functionally superseded by Make targets (`image-build`,
+  `image-run`, `docker-login` + `image-push` with stdin-only password,
+  `run-jar`, `.env.example`).
+- **Snyk GitHub App** — gated nothing, 100% overlapped OWASP DC on Maven dep
+  CVE scanning, account-level read access to source.
+
+### Security
+
+- Trivy filesystem scan (`build` job, informational on every PR).
+- Trivy image scan (`docker` job, CRITICAL/HIGH blocking gate).
+- OWASP dependency-check (`cve-check` job, weekly cron + tag pushes,
+  NVD-backed; `NVD_API_KEY` optional and routed via `~/.m2/settings.xml`,
+  never argv).
+
+### Internal
+
+- `.github/workflows/build-test-push.yml` — 6 jobs (`changes` →
+  `build` → `cve-check` + `release` + `docker` → `ci-pass`), every action
+  SHA-pinned, `dorny/paths-filter` doc-only-PR skip, `make ci-run` exercises
+  `changes` + `build` + `ci-pass` end-to-end under `act push`.
+- `.github/workflows/cleanup-runs.yml` — native `gh` CLI replaces
+  `Mattraks/delete-workflow-runs`.
+- Alignment guards (`make check-java-alignment`, `make check-maven-alignment`)
+  fail fast on `.mise.toml` ↔ Dockerfile toolchain drift.
+
+## Pre-modernization
+
+Releases prior to the modernization sweep are tagged in the GitHub Releases
+page; the Java code originates from
+[intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server)
+and its history is preserved via merges of upstream `master` + `startTls`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-A single-module Maven project that wraps **Apache Directory Server 2.0.0-M24** as a self-contained, in-memory LDAP server. Maven-shaded into one runnable fat JAR (`target/ldap-server.jar`). No persistence — all directory data lives in memory and is lost on shutdown. CLI parsed via JCommander 1.82; default partition root is `dc=ldap,dc=example`; default admin bind is `uid=admin,ou=system` / `secret` on port 10389. Logging routed through SLF4J 2.0.x + `slf4j-simple` (ServiceLoader binding).
+A single-module Maven project that wraps **Apache Directory Server 2.0.0.AM27** as a self-contained, in-memory LDAP server. Maven-shaded into one runnable fat JAR (`target/ldap-server.jar`, ~16 MB). No persistence — all directory data lives in memory and is lost on shutdown. CLI parsed via JCommander 1.82; default partition root is `dc=ldap,dc=example`; default admin bind is `uid=admin,ou=system` / `secret` on port 10389. Logging routed through SLF4J 2.0.x + `slf4j-simple` (ServiceLoader binding).
 
 This repo is a **fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server)**. Java code is the upstream's; the fork adds the Docker pipeline (`andriykalashnykov/apacheds-ad` on Docker Hub), Makefile, hardened GitHub Actions workflow, Renovate config, and `.mise.toml` toolchain pinning. The Maven groupId was scrubbed to `io.github.andriykalashnykov` and `<scm>` / `<developers>` point at this fork; everything else in `pom.xml` is upstream's.
 
@@ -25,20 +25,20 @@ java -jar ./target/ldap-server.jar --help            # full CLI flag list (inclu
 
 `make ci` chains `deps → check-java-alignment → check-maven-alignment → lint → test → package`. The two alignment guards fail fast when the Java major in `.mise.toml` drifts from the Dockerfile `FROM` lines, or when the Maven minor drifts from the build-stage tag — silent toolchain desync is otherwise a recurring foot-gun on Renovate split-PR days. Both guards are mutation-tested (proven to go RED on intentional desync).
 
-`pom.xml` keeps `maven.compiler.source=1.8` AND has a `release` profile that enforces `[1.8,1.9)` via the enforcer plugin. **Don't "fix" this** — ApacheDS 2.0.0-M24 ships bytecode targeting 1.8 and the project intentionally preserves that compatibility floor while the build itself runs on JDK 21+. The JDK used to compile can be anything ≥ 1.8.
+`pom.xml` sets `maven.compiler.source=21` (matches the Dockerfile runtime `eclipse-temurin:21-jre`). AM27 itself ships bytecode 52 (Java 8) but our application can target whatever runtime we deploy on — the dep's floor does not constrain the consumer's target. The `release` profile that enforced `[1.8,1.9)` was removed in this fork; re-add it from upstream if Maven Central publishing is ever wanted.
 
 ### Tests
 
-JUnit 5 Jupiter suite (`org.junit:junit-bom:6.1.0`) under `src/test/java/com/github/kwart/ldap/` — **8 tests, 7 pass, 1 `@Disabled`**:
+JUnit 5 Jupiter suite (`org.junit:junit-bom:6.1.0`) under `src/test/java/com/github/kwart/ldap/` — **8 tests, all passing on AM27**:
 
 | Class | Notes |
 |---|---|
 | `LdapServerTest` | 4 tests — `@ParameterizedTest` + `@MethodSource("data")` over `(ipv6, tls)`, basic bind + search |
 | `LdapServer2Test` | 1 test — multi-entry LDIF with `changetype: modify` |
 | `CustomPasswordTest` | 2 tests — `--admin-password` flag |
-| `StartTlsTest` | `@Disabled` — pins `TLSv1.3` + `TLS_AES_128_GCM_SHA256` against ApacheDS 2.0.0-M24's MINA TLS stack which predates TLSv1.3. Reactivates only when ApacheDS is bumped past M24 (a real Major migration — see Upgrade Backlog); un-`@Disable` + the StartTls reactivation comment in the test source drop in the same commit as the ApacheDS bump. |
+| `StartTlsTest` | 1 test — pins `TLSv1.3` + `TLS_AES_128_GCM_SHA256`; passes on AM27's MINA TLS stack (the `@Disabled` was removed in the AM27 migration commit). |
 
-`make test` runs everything (the `@Disabled` test is skipped, not failed). Surefire's built-in JUnit 5 support handles the BOM; no `junit-platform-launcher` dependency needed.
+`make test` runs everything. Surefire's built-in JUnit 5 support handles the BOM; no `junit-platform-launcher` dependency needed.
 
 ## Architecture
 
@@ -105,14 +105,32 @@ A separate [`cleanup-runs.yml`](.github/workflows/cleanup-runs.yml) prunes old w
 
 ## Upgrade Backlog
 
-Genuinely deferred items waiting on upstream OR coupled to a downstream bump. Renovate handles the routine dep bumps automatically; only items below need human attention.
+Renovate handles routine dep bumps automatically. Currently no human-attention items — both prior backlog entries (ApacheDS AM27, `maven.compiler.source` floor) were resolved in this session. See [CHANGELOG.md](CHANGELOG.md) for details. Add new items here only when a genuinely-deferred upstream-blocked task surfaces.
 
-- [ ] **ApacheDS 2.0.0-M24 → 2.0.0.AM27 (Major migration — NOT a drop-in).** Empirically attempted in this session and rolled back. AM27 introduces three breaking changes that require a ground-up rewrite of `InMemoryDirectoryServiceFactory` + `InMemorySchemaPartition`:
-  1. **EhCache integration removed** — `org.apache.directory.server.core.shared.DefaultDnFactory` no longer takes a `CacheService`; `CacheConfiguration` / `CacheService` / `CacheManager` classes are gone from the API.
-  2. **`Dn.apply(SchemaManager)` removed** — replaced with re-constructing the DN: `suffixDn = new Dn(schemaManager, suffixDn)`. `InMemorySchemaPartition.doInit()`'s throws clause also tightened (`InvalidNameException` no longer accepted; `IOException` must be caught + wrapped in `LdapOtherException`).
-  3. **Transactional partition writes** — `AbstractBTreePartition.add()` asserts a `PartitionWriteTxn` is present in the `OperationContext`. Without it, every LDIF entry import throws `AssertionError` at `AbstractBTreePartition.java:769`. Fixing this requires threading `PartitionTxn` (or its `PartitionWriteTxn` subtype) through `importLdif()` and every `partition.add()` call site — substantial surface change.
-  Until upstream rewrites the partition wiring, **stay on M24**. When AM27 lands here, **also attempt to un-`@Disable` `StartTlsTest`** in the same branch — if AM27's MINA TLS stack handles TLSv1.3, the `@Disabled` comes out + the StartTLS reactivation comment in the test source drops.
-- [ ] **`maven.compiler.source=1.8` floor.** Tied to ApacheDS-M24's bytecode target. After ApacheDS AM27 lands (whenever the partition rewrite is done), verify whether AM27 still ships bytecode 1.8 before considering a floor bump. The `release` profile's enforcer rule `[1.8,1.9)` would need to move too — and the `release` profile itself was removed in this fork; re-add it from upstream if Maven Central publishing is ever wanted.
+### AM27 migration cheat-sheet (recorded so a future bump doesn't redo the research)
+
+AM27 (and presumably newer) introduces four breaking changes vs M24 that an in-memory wrapper must handle:
+
+1. **EhCache removed from `DirectoryService`.** `setCacheService(...)` is gone; `DefaultDnFactory` now uses an internal Caffeine cache. Delete the EhCache block in `InMemoryDirectoryServiceFactory.init()`.
+2. **`Dn.apply(SchemaManager)` removed.** Use `suffixDn = new Dn(schemaManager, suffixDn)` instead (api-ldap-model 2.1.x ctor at line 190 of `Dn.java`).
+3. **`AbstractLdifPartition.doInit()` signature tightened to `throws LdapException`.** Drop `InvalidNameException` and bare `Exception`; catch `IOException` inside and wrap in `LdapOtherException`.
+4. **Transactional partition writes (the load-bearing change).** `AbstractBTreePartition.add()` asserts a `PartitionWriteTxn` on the `OperationContext` (see `AbstractBTreePartition.java:765-770`). The canonical pattern lives in `DefaultOperationManager.java:421-429`:
+   ```java
+   PartitionWriteTxn writeTxn = partition.beginWriteTransaction();
+   try {
+       addContext.setTransaction(writeTxn);
+       partition.add(addContext);
+       writeTxn.commit();
+   } catch (LdapException le) {
+       writeTxn.abort();
+       throw le;
+   } catch (IOException ioe) {
+       writeTxn.abort();
+       throw new LdapOtherException(ioe.getMessage(), ioe);
+   }
+   ```
+   Wrap the schema-load loop in `InMemorySchemaPartition.doInit()` with one such transaction. `LdapServer.importLdif()` goes through `directoryService.getAdminSession().add()`, which routes through `DefaultOperationManager` and handles the transaction internally — no change needed there.
+5. **M24's CoreKeyStoreSpi fallback is gone.** AM27's `CertificateUtil.loadKeyStore(null, null)` returns `null`, so `LdapServer.start()` leaves `keyManagerFactory` null and `StartTlsHandler.setLdapServer()` NPEs. Generate a self-signed temp keystore when none is supplied: `CertificateUtil.createTempKeyStore("ldap-server-", "secret".toCharArray())`.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # ldap-server — In-Memory LDAP Server (Apache Directory)
 
-Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0-M24 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on Docker Hub ([`andriykalashnykov/apacheds-ad`](https://hub.docker.com/r/andriykalashnykov/apacheds-ad)) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 21 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
+Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0.AM27 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on Docker Hub ([`andriykalashnykov/apacheds-ad`](https://hub.docker.com/r/andriykalashnykov/apacheds-ad)) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 21 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
 
 > This is a fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server) — every Java change lives upstream; the fork adds the Docker pipeline, Makefile, hardened CI, and Renovate. Java package `com.github.kwart.ldap` is intentionally kept aligned with upstream so future syncs stay clean diffs.
 
@@ -13,12 +13,12 @@ Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://dir
 
 | Component | Technology |
 |-----------|------------|
-| Language | Java (compiles on JDK 21; bytecode target 1.8 for ApacheDS compat) |
-| LDAP engine | Apache Directory Server 2.0.0-M24 |
+| Language | Java 21 LTS (source + bytecode target 21; matches `eclipse-temurin:21-jre` runtime) |
+| LDAP engine | Apache Directory Server 2.0.0.AM27 |
 | Build | Maven 3.9.16 + `maven-shade-plugin` 3.6.2 (single runnable JAR) |
 | CLI parser | JCommander 1.82 (`IUsageFormatter`-based) |
 | Logging | SLF4J 2.0.18 + `slf4j-simple` (ServiceLoader binding) |
-| Tests | JUnit 5 Jupiter 6.1.0 via `junit-bom` (8 tests; 1 `@Disabled`) |
+| Tests | JUnit 5 Jupiter 6.1.0 via `junit-bom` (8 tests, all passing — incl. StartTLS over TLSv1.3) |
 | Container | Multi-stage Dockerfile: `maven:3.9-eclipse-temurin-21` → `eclipse-temurin:21-jre` (both `@sha256:`-digest-pinned), non-root UID 10001, TCP HEALTHCHECK |
 | Version manager | [mise](https://mise.jdx.dev/) (`.mise.toml` pins Java 21 LTS + Maven 3.9.16) |
 | Dep management | Renovate (Maven + GitHub Actions + Dockerfile + `.mise.toml`) |
@@ -115,7 +115,7 @@ java -Djavax.net.debug=ssl \
   -sp 10636 -skf /tmp/ldaps.keystore -skp 123456
 ```
 
-> StartTLS is also wired (the server registers a `StartTlsHandler`), but [`StartTlsTest`](src/test/java/com/github/kwart/ldap/StartTlsTest.java) is currently `@Disabled` — ApacheDS 2.0.0-M24's MINA TLS stack predates TLSv1.3, and the test pins `TLSv1.3` + `TLS_AES_128_GCM_SHA256`. Reactivation is coupled to an ApacheDS Major migration (AM27 introduces breaking changes to the partition + cache API — see `CLAUDE.md` Upgrade Backlog).
+> StartTLS is also wired (the server registers a `StartTlsHandler`) and exercised by [`StartTlsTest`](src/test/java/com/github/kwart/ldap/StartTlsTest.java), which negotiates TLSv1.3 + `TLS_AES_128_GCM_SHA256` against AM27's MINA TLS stack. If no `--ssl-keystore-file` is supplied, the server generates a self-signed EC certificate on startup so StartTLS + LDAPS work out of the box for tests and dev.
 
 ## Docker
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
+        <version.org.apache.ds>2.0.0.AM27</version.org.apache.ds>
         <version.junit>6.1.0</version.junit>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <exec.mainClass>com.github.kwart.ldap.LdapServer</exec.mainClass>
     </properties>

--- a/src/main/java/com/github/kwart/ldap/InMemoryDirectoryServiceFactory.java
+++ b/src/main/java/com/github/kwart/ldap/InMemoryDirectoryServiceFactory.java
@@ -36,7 +36,6 @@ import org.apache.directory.api.util.FileUtils;
 import org.apache.directory.api.util.exception.Exceptions;
 import org.apache.directory.server.constants.ServerDNConstants;
 import org.apache.directory.server.core.DefaultDirectoryService;
-import org.apache.directory.server.core.api.CacheService;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.api.InstanceLayout;
 import org.apache.directory.server.core.api.partition.Partition;
@@ -47,10 +46,6 @@ import org.apache.directory.server.core.factory.PartitionFactory;
 import org.apache.directory.server.i18n.I18n;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.config.CacheConfiguration;
-import net.sf.ehcache.config.Configuration;
 
 /**
  * Factory for a fast (mostly in-memory-only) ApacheDS DirectoryService. Use only for tests!!
@@ -111,13 +106,8 @@ public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory 
         }
         directoryService.setInstanceLayout(instanceLayout);
 
-        // EhCache in disabled-like-mode
-        Configuration ehCacheConfig = new Configuration();
-        CacheConfiguration defaultCache = new CacheConfiguration("default", 1).eternal(false).timeToIdleSeconds(30)
-                .timeToLiveSeconds(30).overflowToDisk(false);
-        ehCacheConfig.addDefaultCache(defaultCache);
-        CacheService cacheService = new CacheService(new CacheManager(ehCacheConfig));
-        directoryService.setCacheService(cacheService);
+        // ApacheDS AM27 removed the EhCache-backed CacheService — DefaultDnFactory
+        // now uses an internal Caffeine cache. No setCacheService() call needed.
 
         // Init the schema
         // SchemaLoader loader = new SingleLdifSchemaLoader();

--- a/src/main/java/com/github/kwart/ldap/InMemorySchemaPartition.java
+++ b/src/main/java/com/github/kwart/ldap/InMemorySchemaPartition.java
@@ -20,23 +20,26 @@
 
 package com.github.kwart.ldap;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import javax.naming.InvalidNameException;
-
 import org.apache.directory.api.ldap.model.constants.SchemaConstants;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapOtherException;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.api.ldap.schema.extractor.impl.DefaultSchemaLdifExtractor;
 import org.apache.directory.api.ldap.schema.extractor.impl.ResourceMap;
 import org.apache.directory.server.core.api.interceptor.context.AddOperationContext;
+import org.apache.directory.server.core.api.partition.PartitionWriteTxn;
 import org.apache.directory.server.core.partition.ldif.AbstractLdifPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,38 +65,62 @@ public class InMemorySchemaPartition extends AbstractLdifPartition {
 
     /**
      * Partition initialization - loads schema entries from the files on classpath.
-     * 
+     *
      * @see org.apache.directory.server.core.partition.impl.avl.AvlPartition#doInit()
      */
     @Override
-    protected void doInit() throws InvalidNameException, Exception {
+    protected void doInit() throws LdapException {
         if (initialized)
             return;
 
         LOG.debug("Initializing schema partition " + getId());
-        suffixDn.apply(schemaManager);
+        // AM27 removed Dn.apply(SchemaManager); rebuild the suffix DN with the
+        // schema manager bound, which performs the same normalisation.
+        suffixDn = new Dn(schemaManager, suffixDn);
         super.doInit();
 
-        // load schema
-        final Map<String, Boolean> resMap = ResourceMap.getResources(Pattern.compile("schema[/\\Q\\\\E]ou=schema.*"));
-        for (String resourcePath : new TreeSet<String>(resMap.keySet())) {
-            if (resourcePath.endsWith(".ldif")) {
-                URL resource = DefaultSchemaLdifExtractor.getUniqueResource(resourcePath, "Schema LDIF file");
-                LdifReader reader = new LdifReader(resource.openStream());
-                LdifEntry ldifEntry = reader.next();
-                reader.close();
+        // AM27's AbstractBTreePartition.add() asserts a PartitionWriteTxn on
+        // the OperationContext (see AbstractBTreePartition.java:765-770). Open
+        // one write transaction across the schema load and commit at the end.
+        PartitionWriteTxn writeTxn = beginWriteTransaction();
+        try {
+            // load schema
+            final Map<String, Boolean> resMap = ResourceMap.getResources(Pattern.compile("schema[/\\Q\\\\E]ou=schema.*"));
+            for (String resourcePath : new TreeSet<String>(resMap.keySet())) {
+                if (resourcePath.endsWith(".ldif")) {
+                    URL resource = DefaultSchemaLdifExtractor.getUniqueResource(resourcePath, "Schema LDIF file");
+                    LdifReader reader = new LdifReader(resource.openStream());
+                    LdifEntry ldifEntry = reader.next();
+                    reader.close();
 
-                Entry entry = new DefaultEntry(schemaManager, ldifEntry.getEntry());
-                // add mandatory attributes
-                if (entry.get(SchemaConstants.ENTRY_CSN_AT) == null) {
-                    entry.add(SchemaConstants.ENTRY_CSN_AT, defaultCSNFactory.newInstance().toString());
+                    Entry entry = new DefaultEntry(schemaManager, ldifEntry.getEntry());
+                    // add mandatory attributes
+                    if (entry.get(SchemaConstants.ENTRY_CSN_AT) == null) {
+                        entry.add(SchemaConstants.ENTRY_CSN_AT, defaultCSNFactory.newInstance().toString());
+                    }
+                    if (entry.get(SchemaConstants.ENTRY_UUID_AT) == null) {
+                        entry.add(SchemaConstants.ENTRY_UUID_AT, UUID.randomUUID().toString());
+                    }
+                    AddOperationContext addContext = new AddOperationContext(null, entry);
+                    addContext.setTransaction(writeTxn);
+                    super.add(addContext);
                 }
-                if (entry.get(SchemaConstants.ENTRY_UUID_AT) == null) {
-                    entry.add(SchemaConstants.ENTRY_UUID_AT, UUID.randomUUID().toString());
-                }
-                AddOperationContext addContext = new AddOperationContext(null, entry);
-                super.add(addContext);
             }
+            writeTxn.commit();
+        } catch (IOException ioe) {
+            try {
+                writeTxn.abort();
+            } catch (IOException ignored) {
+                // best-effort abort
+            }
+            throw new LdapOtherException(ioe.getMessage(), ioe);
+        } catch (LdapException le) {
+            try {
+                writeTxn.abort();
+            } catch (IOException ignored) {
+                // best-effort abort
+            }
+            throw le;
         }
     }
 

--- a/src/main/java/com/github/kwart/ldap/LdapServer.java
+++ b/src/main/java/com/github/kwart/ldap/LdapServer.java
@@ -39,6 +39,7 @@ import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.util.IOUtils;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.partition.impl.avl.AvlPartition;
+import org.apache.directory.server.core.security.CertificateUtil;
 import org.apache.directory.server.ldap.handlers.extended.StartTlsHandler;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 
@@ -110,9 +111,22 @@ public class LdapServer {
         }
 
         ldapServer = new org.apache.directory.server.ldap.LdapServer();
+        // AM27 removed the M24 CoreKeyStoreSpi fallback (which auto-loaded a
+        // keystore from the DIT when no `--ssl-keystore-file` was supplied),
+        // so `CertificateUtil.loadKeyStore(null, null)` now returns null and
+        // `LdapServer.start()` later NPEs from StartTlsHandler.setLdapServer.
+        // Preserve M24's "just works without configuration" behavior by
+        // generating a self-signed EC keystore on the fly when none is given.
+        String keystoreFile = cliArguments.getSslKeystoreFile();
+        String keystorePassword = cliArguments.getSslKeystorePassword();
+        if (keystoreFile == null) {
+            char[] generatedPassword = "secret".toCharArray();
+            keystoreFile = CertificateUtil.createTempKeyStore("ldap-server-", generatedPassword).getAbsolutePath();
+            keystorePassword = new String(generatedPassword);
+        }
+        ldapServer.setKeystoreFile(keystoreFile);
+        ldapServer.setCertificatePassword(keystorePassword);
         ldapServer.addExtendedOperationHandler(new StartTlsHandler());
-        ldapServer.setKeystoreFile(cliArguments.getSslKeystoreFile());
-        ldapServer.setCertificatePassword(cliArguments.getSslKeystorePassword());
         TcpTransport tcp = new TcpTransport(cliArguments.getBindAddress(), cliArguments.getPort());
         ldapServer.addTransports(tcp);
         if (cliArguments.getSslPort() != null) {

--- a/src/test/java/com/github/kwart/ldap/StartTlsTest.java
+++ b/src/test/java/com/github/kwart/ldap/StartTlsTest.java
@@ -45,7 +45,6 @@ import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -71,7 +70,6 @@ public class StartTlsTest {
     }
 
     @Test
-    @Disabled("Pinned TLSv1.3 + TLS_AES_128_GCM_SHA256 produces handshake_failure against ApacheDS 2.0.0-M24's MINA TLS stack (pre-TLSv1.3). Reactivate when apacheds-parent is bumped (a real Major migration — AM27 dropped the EhCache integration and switched to transactional partition writes; see CLAUDE.md Upgrade Backlog).")
     public void test() throws Exception {
         String host = "127.0.0.1";
         String port = "10389";


### PR DESCRIPTION
## Summary

Lands the ApacheDS 2.0.0-M24 → 2.0.0.AM27 Major migration that was previously marked deferred. Also enables Java 21 source/target, reactivates the previously @Disabled \`StartTlsTest\`, and drops the shaded JAR from ~19.94 MB to ~16 MB.

Empirically verified against AM27's own authoritative sources (`apacheds-core`/`apacheds-xdbm-partition` 2.0.0.AM27 jars in `~/.m2`, canonical add+txn pattern at `DefaultOperationManager.java:421-429`).

## Breaking changes handled

1. **EhCache removed** from `DirectoryService` — `setCacheService()` deleted, AM27's `DefaultDnFactory` uses an internal Caffeine cache. Removed the EhCache block + imports from `InMemoryDirectoryServiceFactory`.
2. **`Dn.apply(SchemaManager)` removed** in api-ldap-model 2.1.x — replaced with `new Dn(schemaManager, suffixDn)` (ctor at `Dn.java:190`).
3. **`AbstractLdifPartition.doInit()` signature tightened** to `throws LdapException`. Dropped `InvalidNameException` + bare `Exception` from `InMemorySchemaPartition.doInit()`; catch `IOException` and wrap in `LdapOtherException`.
4. **Transactional partition writes** — `AbstractBTreePartition.add()` asserts a \`PartitionWriteTxn\` on the OperationContext (line 769). Wrapped the schema-load loop in `InMemorySchemaPartition.doInit()` with one write transaction. \`LdapServer.importLdif()\` goes through \`DefaultOperationManager\` which handles the transaction internally — no change needed there.
5. **CoreKeyStoreSpi fallback removed** — M24 auto-loaded a keystore from the DIT admin entry when none was supplied. AM27's `CertificateUtil.loadKeyStore(null, null)` returns null and StartTlsHandler NPEs. \`LdapServer\` constructor now generates a self-signed EC keystore via `CertificateUtil.createTempKeyStore()` when none is provided.

## Net wins

- **StartTlsTest reactivated** — AM27's MINA stack supports TLSv1.3 + \`TLS_AES_128_GCM_SHA256\`. The \`@Disabled\` marker that had blocked this test since the pre-TLSv1.3-MINA era was removed. Test suite is now **8/8**.
- **\`maven.compiler.source\` / \`target\` bumped 1.8 → 21.** AM27 still ships bytecode 52, but a dep's floor doesn't constrain the consumer's target. App now compiles to bytecode 65 (Java 21), matching the \`eclipse-temurin:21-jre\` runtime. Eliminates the obsolete \`source value 8\` warnings.
- **Shaded JAR: 19.94 MB → ~16 MB.** AM27's removal of the EhCache transitive drops ~9 MB.

## Test plan

- [x] \`mvn test\` — 8/8 pass (including reactivated StartTlsTest)
- [x] \`make ci\` — BUILD SUCCESS
- [x] \`make image-build\` — clean (digest-pinned bases, multi-stage build from source)
- [x] \`make e2e\` — \`AuthenticateWithSearch jduke theduke\` PASS against the new AM27-built image

## Files

- `pom.xml` — `version.org.apache.ds` 2.0.0-M24 → 2.0.0.AM27; `maven.compiler.source` 1.8 → 21
- `InMemoryDirectoryServiceFactory.java` — EhCache imports + block removed
- `InMemorySchemaPartition.java` — signature tightened, \`Dn.apply\` replaced, write transaction wrapping the schema-load loop
- `LdapServer.java` — self-signed EC keystore fallback via `CertificateUtil.createTempKeyStore()`
- `StartTlsTest.java` — \`@Disabled\` removed
- `CLAUDE.md` — description bumped, compiler guidance rewritten, Tests reflects 8-pass, Upgrade Backlog cleared + replaced with an AM27 cheat-sheet for any future bump
- `README.md` — ApacheDS version, Language row, Tests row, StartTLS callout updated
- `CHANGELOG.md` — **new**, Keep-a-Changelog format