### PR TITLE
release: bump version to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.github.andriykalashnykov</groupId>
     <artifactId>ldap-server</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>ldap-server</name>


### PR DESCRIPTION
Prep for the `v1.1.0` tag. Drops the vestigial `-SNAPSHOT` suffix (no Maven deploy / distributionManagement, so the suffix served no purpose). Once merged, the `v1.1.0` tag will trigger the `docker` job → Docker Hub image push (`andriykalashnykov/apacheds-ad:1.1.0` / `1.1` / `1` / `latest` per `docker/metadata-action` fan-out).

## Test plan

- [x] `make ci` BUILD SUCCESS (8/8 tests including reactivated StartTlsTest)