### PR TITLE
fix(security): mina-core -> 2.2.7 + base image -> alpine (CVE fixes from v1.1.0 docker scan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and dependency / source migrations driven by the fork) are recorded below.
 
 ## [Unreleased]
 
+### Security
+
+- **mina-core pinned to 2.2.7** via `dependencyManagement` to override
+  ApacheDS AM27's transitive mina-core 2.2.3, which carried CVE-2024-52046
+  (CRITICAL — unbounded deserialization may allow RCE). Removable once
+  upstream ApacheDS ships a release with mina ≥ 2.2.4.
+- **Runtime base image switched from `eclipse-temurin:21-jre`
+  (Ubuntu) to `eclipse-temurin:21-jre-alpine`.** The Ubuntu variant
+  bundled Go binaries whose `stdlib v1.26.2` triggered 8 HIGH Trivy
+  findings (CVE-2026-33811 et al.) with no Eclipse-Temurin-published
+  fix yet. The alpine variant ships no Go binaries (Trivy-clean at
+  switch time, OS layer alpine 3.23.4) and uses busybox `nc` for the
+  HEALTHCHECK in place of bash `/dev/tcp`. Dockerfile's `useradd` /
+  `groupadd` swapped to busybox `adduser` / `addgroup` (`-S`/`-D`/`-H`
+  short flags). `Makefile` `e2e` target's `--health-cmd` override
+  swapped to match (`nc -z localhost ${APP_INTERNAL_PORT}`).
+
 ### Added
 
 - **ApacheDS 2.0.0.AM27 migration** (real Major migration, formerly deferred).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,9 @@ Entry point is `com.github.kwart.ldap.LdapServer#main`, declared as the shaded J
 Multi-stage Dockerfile, builds from source — does NOT download a released JAR.
 
 - **Builder**: `maven:3.9-eclipse-temurin-21` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
-- **Runtime**: `eclipse-temurin:21-jre`. Non-root user UID/GID 10001 (created via `useradd`, no home, `/usr/sbin/nologin` shell). Owns `/ldap`.
-- **HEALTHCHECK**: `bash -c 'exec 3<>/dev/tcp/${HEALTHCHECK_HOST}/${APP_INTERNAL_PORT}'`. Uses bash's `/dev/tcp` because (a) ApacheDS exposes only the LDAP protocol — no HTTP `/healthz` — and (b) `eclipse-temurin:21-jre` ships bash but not `curl`/`nc`/`wget`. **No apt install in the runtime layer.**
-- **`HEALTHCHECK` flag timings are LITERAL** (`--interval=30s --timeout=3s --start-period=20s --retries=3`) because Docker's parser does NOT expand ARG/ENV in those slots. The CMD's `${VAR}` inside the nested `bash -c '...'` ARE expanded at container start, so `HEALTHCHECK_HOST` and `APP_INTERNAL_PORT` honor `docker run -e ...` overrides.
+- **Runtime**: `eclipse-temurin:21-jre-alpine` (alpine variant; ~41 MB `/usr`, no Go binaries to drag in stdlib CVEs, Trivy-clean at time of switch). Non-root user UID/GID 10001 (created via busybox `addgroup`/`adduser`, no home, `/sbin/nologin` shell). Owns `/ldap`.
+- **HEALTHCHECK**: `nc -z ${HEALTHCHECK_HOST} ${APP_INTERNAL_PORT}` — busybox netcat is bundled with alpine; no extra package install needed. Probes the LDAP TCP listener since ApacheDS exposes only the LDAP protocol (no HTTP `/healthz`). The previous `bash -c 'exec 3<>/dev/tcp/...'` form was Ubuntu-base specific; alpine's busybox sh has no `/dev/tcp`. **No `apk add` in the runtime layer.**
+- **`HEALTHCHECK` flag timings are LITERAL** (`--interval=30s --timeout=3s --start-period=20s --retries=3`) because Docker's parser does NOT expand ARG/ENV in those slots. The CMD's `${VAR}` expand at container start, so `HEALTHCHECK_HOST` and `APP_INTERNAL_PORT` honor `docker run -e ...` overrides.
 - **CMD**: shell form so `${APP_INTERNAL_PORT}` is honored — `java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/`.
 
 ### Container workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN test -s /workspace/target/ldap-server.jar
 # =============================================================================
 # Runtime stage — slim JRE, non-root, env-driven tunables
 # =============================================================================
-FROM eclipse-temurin:21-jre@sha256:010e0a06bd4e0184dec58626afb3ba727b42c56c91b977e2f0a9e0837e0fa3fb
+FROM eclipse-temurin:21-jre-alpine@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
 
 # === Operator tunables (slot 2 — ARG defaults; see configuration.md) ===
 ARG APP_INTERNAL_PORT=10389
@@ -46,11 +46,10 @@ LABEL maintainer="AndriyKalashnykov@gmail.com" \
       org.opencontainers.image.source="https://github.com/AndriyKalashnykov/ldap-server" \
       org.opencontainers.image.description="In-memory LDAP server based on ApacheDS"
 
-# Non-root user. /usr/sbin/nologin denies interactive shells; no home dir
-# minimizes attack surface.
-RUN groupadd --system --gid ${APP_GID} ldap \
- && useradd  --system --uid ${APP_UID} --gid ${APP_GID} \
-        --no-create-home --shell /usr/sbin/nologin ldap
+# Non-root user. Alpine ships busybox `addgroup`/`adduser`; -S = system,
+# -D = no password, -H = no home. /sbin/nologin denies interactive shells.
+RUN addgroup -S -g ${APP_GID} ldap \
+ && adduser  -S -u ${APP_UID} -G ldap -H -D -s /sbin/nologin ldap
 
 RUN mkdir -p /ldap/ldif \
  && chown -R ${APP_UID}:${APP_GID} /ldap
@@ -65,13 +64,13 @@ USER ${APP_UID}
 EXPOSE ${APP_INTERNAL_PORT}
 
 # ApacheDS exposes only the LDAP protocol — no HTTP /healthz. Probe the
-# TCP listener via bash's /dev/tcp (bundled with eclipse-temurin's bash;
-# no apt-install of nc / curl needed). HEALTHCHECK flag values are
-# literal — Docker's parser does NOT expand ARG/ENV in --interval/etc.,
-# so timings are hardcoded here. The CMD's `${VAR}` expand at container
-# start, so HEALTHCHECK_HOST / APP_INTERNAL_PORT honor `docker run -e`.
+# TCP listener via busybox `nc -z` (bundled with alpine; no extra
+# package install needed). HEALTHCHECK flag values are literal — Docker's
+# parser does NOT expand ARG/ENV in --interval/etc., so timings are
+# hardcoded here. The CMD's `${VAR}` expand at container start, so
+# HEALTHCHECK_HOST / APP_INTERNAL_PORT honor `docker run -e`.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
-    CMD bash -c 'exec 3<>/dev/tcp/${HEALTHCHECK_HOST}/${APP_INTERNAL_PORT}' || exit 1
+    CMD nc -z "${HEALTHCHECK_HOST}" "${APP_INTERNAL_PORT}" || exit 1
 
 # Mount any directory with `.ldif` files to /ldap/ldif/ to seed the server,
 # e.g. `docker run -v ./ldif:/ldap/ldif/ ...`. An empty mount leaves the

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ e2e:
 	trap 'docker rm -f "'"$$SERVER"'" >/dev/null 2>&1 || true; docker network rm "'"$$NET"'" >/dev/null 2>&1 || true' EXIT INT TERM; \
 	docker run -d --name="$$SERVER" --network="$$NET" \
 		--entrypoint java \
-		--health-cmd "bash -c 'exec 3<>/dev/tcp/localhost/$(APP_INTERNAL_PORT)'" \
+		--health-cmd "nc -z localhost $(APP_INTERNAL_PORT)" \
 		--health-interval=2s --health-timeout=2s --health-start-period=5s --health-retries=10 \
 		"$(IMAGE_REF)" \
 		-jar /ldap/ldap-server.jar -b 0.0.0.0 -p $(APP_INTERNAL_PORT) >/dev/null; \

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,16 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- CVE override: AM27's apacheds-protocol-ldap transitively pulls
+                 mina-core 2.2.3 (CVE-2024-52046, CRITICAL — unbounded
+                 deserialization may allow RCE; fixed in 2.2.4+). Pin to the
+                 latest 2.2.x patch to override the transitive. Removable once
+                 ApacheDS ships a release with mina >= 2.2.4. -->
+            <dependency>
+                <groupId>org.apache.mina</groupId>
+                <artifactId>mina-core</artifactId>
+                <version>2.2.7</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary

The `v1.1.0` tag's docker job correctly failed the Trivy CRITICAL/HIGH gate before pushing to Docker Hub. Two real CVE classes surfaced — both fixed here.

## Fix 1 — mina-core 2.2.3 -> 2.2.7 (CRITICAL)

ApacheDS AM27 transitively pulls `mina-core 2.2.3` which carries [CVE-2024-52046](https://avd.aquasec.com/nvd/cve-2024-52046) (Apache MINA: unbounded deserialization may allow RCE; CRITICAL). Patched in mina 2.2.4; pin to the latest 2.2.x in `<dependencyManagement>` overrides the transitive. The shaded JAR now contains `mina-core-2.2.7.jar`. Removable once upstream ApacheDS BOMs mina ≥ 2.2.4.

## Fix 2 — base image: `eclipse-temurin:21-jre` -> `eclipse-temurin:21-jre-alpine` (8 HIGH)

The Ubuntu-based variant bundles Go binaries whose `stdlib v1.26.2` triggered 8 HIGH Trivy findings (CVE-2026-33811 et al.) — no Eclipse-Temurin-published fix exists for that image yet. The alpine variant is Trivy-clean at switch time (alpine 3.23.4, no Go binaries), smaller (/usr is 41 MB vs ~150 MB), and ships busybox `nc` so the HEALTHCHECK no longer needs bash.

Alpine swap touches:
- Dockerfile FROM @sha256 (`@sha256:704db3c4...`, multi-arch index)
- User creation: `groupadd`/`useradd` -> busybox `addgroup -S` / `adduser -S -G -H -D -s /sbin/nologin`
- HEALTHCHECK CMD: `bash -c 'exec 3<>/dev/tcp/...'` -> `nc -z HOST PORT`
- Makefile `e2e` target's `--health-cmd` override updated to match (alpine has no `/dev/tcp`).

## Test plan

- [x] `mvn -B dependency:tree -Dincludes=org.apache.mina:mina-core` -> `mina-core:jar:2.2.7`
- [x] `make ci` BUILD SUCCESS (8/8 tests)
- [x] `make image-build` clean on alpine
- [x] `make e2e` LDAP-bind + search PASS against alpine image

## Note on cve-check failure (separate, upstream issue)

The `cve-check` job also failed on the v1.1.0 run with an upstream NPE in OWASP dependency-check 12.2.2's NVD-data processing (`commons-dbcp2.BasicDataSource.getConnection() — connectionPool is null`). 12.2.2 is the latest plugin release; no newer version to bump to. cve-check is independent of image publishing — leaving as a known upstream bug for the weekly cron / workflow_dispatch retry path.