### PR TITLE
release: bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The fork inherits the upstream Java code from
 fork-owned changes (Docker pipeline, Makefile, hardened CI, Renovate config,
 and dependency / source migrations driven by the fork) are recorded below.
 
-## [Unreleased]
+## [1.1.1] — 2026-05-31
 
 ### Security
 
@@ -27,6 +27,17 @@ and dependency / source migrations driven by the fork) are recorded below.
   `groupadd` swapped to busybox `adduser` / `addgroup` (`-S`/`-D`/`-H`
   short flags). `Makefile` `e2e` target's `--health-cmd` override
   swapped to match (`nc -z localhost ${APP_INTERNAL_PORT}`).
+
+## [1.1.0] — superseded by 1.1.1
+
+The `v1.1.0` git tag exists but never published a Docker Hub image: the
+`docker` job's Trivy CRITICAL/HIGH gate (working as designed) blocked
+the push when it surfaced mina-core CVE-2024-52046 (CRITICAL) and 8
+HIGH Go-stdlib CVEs in the Ubuntu-based `eclipse-temurin:21-jre` base.
+Both are fixed in 1.1.1. The `Latest` GitHub Release was updated with
+the 1.1.0 JAR (the `release` job succeeded independently); the 1.1.1
+release supersedes it. The migration content shipped in 1.1.0 is
+unchanged in 1.1.1 — see the items below.
 
 ### Added
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.github.andriykalashnykov</groupId>
     <artifactId>ldap-server</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>ldap-server</name>


### PR DESCRIPTION
Patch release to re-cut the 1.1.x release process after PR #10's CVE fixes (mina-core 2.2.7 override + alpine base image). The v1.1.0 git tag exists but its docker job was correctly blocked by the Trivy gate — no v1.1.0 Docker Hub image was published.

Once merged, the v1.1.1 tag will trigger the docker job → Docker Hub image push (`andriykalashnykov/apacheds-ad:1.1.1` / `1.1` / `1` / `latest`).