### PR TITLE
feat(ci): migrate image registry Docker Hub -> GHCR + bump 1.1.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,16 @@
 # Loaded automatically by Make via ?= fallbacks.
 
 # === Docker image coordinates ===
-# Push target is ${DOCKER_LOGIN}/${IMAGE_NAME}:${IMAGE_TAG} on Docker Hub.
-DOCKER_REGISTRY=registry-1.docker.io
+# Push target is ${DOCKER_REGISTRY}/${DOCKER_LOGIN}/${IMAGE_NAME}:${IMAGE_TAG}.
+# Default registry: ghcr.io. For the canonical CI-matching path, set
+# DOCKER_LOGIN=<github-owner>/ldap-server (repo-namespace) — required
+# when using GITHUB_TOKEN. The bare-owner form (`<owner>/apacheds-ad`)
+# needs a PAT with `write:packages` scope.
+DOCKER_REGISTRY=ghcr.io
 DOCKER_LOGIN=
 # DOCKER_PWD is a secret: keep in your gitignored .env, NEVER on the
 # command line (passes via stdin to `docker login --password-stdin`).
+# For GHCR locally, use a GitHub PAT with `write:packages` scope.
 # DOCKER_PWD=
 IMAGE_NAME=apacheds-ad
 IMAGE_TAG=latest

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -181,7 +181,7 @@ jobs:
           make_latest: 'true'
           files: ldap-server.jar
 
-  # Build + push the Docker image to Docker Hub on v* tag pushes only
+  # Build + push the Docker image to GHCR on v* tag pushes only
   # (preserves legacy behavior). The multi-stage Dockerfile builds the JAR
   # from source — no dependency on the `release` job's GH Release upload.
   # Pre-push gates: Trivy image scan (CRITICAL/HIGH blocking) + smoke test
@@ -196,6 +196,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: write          # required to publish to ghcr.io via GITHUB_TOKEN
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -206,7 +207,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/apacheds-ad
+          # Repo-namespace GHCR path (ghcr.io/<owner>/<repo>/<pkg>) — required
+          # for `GITHUB_TOKEN` to publish (user-namespace `ghcr.io/<owner>/<pkg>`
+          # requires a PAT with write:packages). metadata-action lowercases the
+          # produced tags automatically — `github.repository` preserves case
+          # but the output tags are all lowercase.
+          images: ghcr.io/${{ github.repository }}/apacheds-ad
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -252,11 +258,12 @@ jobs:
         run: make e2e IMAGE_REF=apacheds-ad:scan
 
       # ---- All gates passed: log in + push (second build = ~full cache hit)
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,44 @@ The fork inherits the upstream Java code from
 fork-owned changes (Docker pipeline, Makefile, hardened CI, Renovate config,
 and dependency / source migrations driven by the fork) are recorded below.
 
-## [1.1.1] — 2026-05-31
+## [1.1.2] — 2026-05-31
+
+### Changed
+
+- **Image registry: Docker Hub → GHCR.** The `docker` job now publishes
+  to `ghcr.io/<owner>/ldap-server/apacheds-ad` using the auto-provisioned
+  `GITHUB_TOKEN` (scoped via `permissions: packages: write` on the
+  docker job only). Migration touches:
+  - `.github/workflows/build-test-push.yml` — `docker/metadata-action`
+    images: `ghcr.io/${{ github.repository }}/apacheds-ad`;
+    `docker/login-action` registry `ghcr.io`, username
+    `${{ github.actor }}`, password `${{ secrets.GITHUB_TOKEN }}`;
+    job-level `packages: write` added.
+  - `Makefile` — `DOCKER_REGISTRY ?= ghcr.io` (was `registry-1.docker.io`).
+  - `.env.example` — `DOCKER_REGISTRY=ghcr.io`.
+  - `CLAUDE.md` + `README.md` — every Docker-Hub reference rewritten
+    to GHCR; Required-secrets table no longer lists `DOCKERHUB_*`
+    secrets (legacy pair can be deleted from the repo); fork-identity
+    sentence updated.
+
+  The legacy `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` secrets are no
+  longer used by any workflow step and should be removed from the
+  repo. The 2021-dated PAT was the immediate trigger for this
+  migration — its expiration blocked the v1.1.1 image push despite
+  every CVE gate passing.
+
+  The legacy Docker Hub image `andriykalashnykov/apacheds-ad` will
+  not receive further updates; consumers should switch to
+  `ghcr.io/andriykalashnykov/ldap-server/apacheds-ad` starting at
+  v1.1.2.
+
+## [1.1.1] — 2026-05-31 — superseded by 1.1.2
+
+Cut as the patch over the v1.1.0 CVE-blocked release; the v1.1.1
+`docker` job passed all gates (Trivy, smoke, e2e) but its `Log in to
+Docker Hub` step failed (expired 2021 PAT). No Docker Hub image
+landed for v1.1.1; the security content shipped in v1.1.2 along with
+the GHCR migration.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A single-module Maven project that wraps **Apache Directory Server 2.0.0.AM27** as a self-contained, in-memory LDAP server. Maven-shaded into one runnable fat JAR (`target/ldap-server.jar`, ~16 MB). No persistence — all directory data lives in memory and is lost on shutdown. CLI parsed via JCommander 1.82; default partition root is `dc=ldap,dc=example`; default admin bind is `uid=admin,ou=system` / `secret` on port 10389. Logging routed through SLF4J 2.0.x + `slf4j-simple` (ServiceLoader binding).
 
-This repo is a **fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server)**. Java code is the upstream's; the fork adds the Docker pipeline (`andriykalashnykov/apacheds-ad` on Docker Hub), Makefile, hardened GitHub Actions workflow, Renovate config, and `.mise.toml` toolchain pinning. The Maven groupId was scrubbed to `io.github.andriykalashnykov` and `<scm>` / `<developers>` point at this fork; everything else in `pom.xml` is upstream's.
+This repo is a **fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server)**. Java code is the upstream's; the fork adds the Docker pipeline (`ghcr.io/andriykalashnykov/ldap-server/apacheds-ad` on GitHub Container Registry), Makefile, hardened GitHub Actions workflow, Renovate config, and `.mise.toml` toolchain pinning. The Maven groupId was scrubbed to `io.github.andriykalashnykov` and `<scm>` / `<developers>` point at this fork; everything else in `pom.xml` is upstream's.
 
 **Java package `com.github.kwart.ldap` is intentionally kept aligned with upstream** (not renamed to the fork's identity) so future `git merge upstream/master` runs stay clean diffs. Don't propose renaming it.
 
@@ -88,12 +88,12 @@ Six jobs, every action SHA-pinned:
 | `build` | code-changing events + every tag | `jdx/mise-action` provisions Java + Maven from `.mise.toml`; `actions/cache` keyed on `hashFiles('pom.xml')` for `~/.m2/repository`. Runs `make ci` (alignment guards + lint + test + package). Trivy filesystem scan (informational). Uploads `target/ldap-server.jar` as artifact. |
 | `cve-check` | tag pushes + weekly cron + dispatch | OWASP dependency-check via `mvn org.owasp:dependency-check-maven:check`. NVD DB cached at `~/.m2/repository/org/owasp/dependency-check-data` keyed on `pom.xml`. `NVD_API_KEY` optional (routed via `~/.m2/settings.xml`, never argv). |
 | `release` | push to `master` OR `v*` tag | Downloads JAR, recreates the `latest` GitHub Release via `softprops/action-gh-release`. `contents: write` scoped to this job only. |
-| `docker` | `v*` tag only | Build image for scan (load: true, amd64) → Trivy CRITICAL/HIGH image scan → `make image-smoke-test IMAGE_REF=apacheds-ad:scan` → `make e2e IMAGE_REF=apacheds-ad:scan` → log in to Docker Hub → push single-arch `linux/amd64` image with `provenance: false` + `sbom: false` and `flavor: latest=true` (only retags `:latest` for the highest-precedence semver). Each gate blocks the push. |
+| `docker` | `v*` tag only | Build image for scan (load: true, amd64) → Trivy CRITICAL/HIGH image scan → `make image-smoke-test IMAGE_REF=apacheds-ad:scan` → `make e2e IMAGE_REF=apacheds-ad:scan` → log in to **GHCR** (`${{ github.actor }}` + auto-provisioned `GITHUB_TOKEN`; the docker job has `packages: write`) → push single-arch `linux/amd64` image to `ghcr.io/${{ github.repository }}/apacheds-ad` with `provenance: false` + `sbom: false` and `flavor: latest=true` (only retags `:latest` for the highest-precedence semver). Each gate blocks the push. |
 | `ci-pass` | always | Single branch-protection aggregator. Treats skipped as pass (handles tag-only `docker`/`cve-check`, master-or-tag-only `release`, doc-only-PR-skipping everything). |
 
 A separate [`cleanup-runs.yml`](.github/workflows/cleanup-runs.yml) prunes old workflow runs and caches from deleted branches weekly via the native `gh` CLI (the previous `Mattraks/delete-workflow-runs` was migrated off per portfolio policy — single-maintainer third-party action, replaced by built-in tooling).
 
-**`make ci-run` coverage gap.** `act push` exercises `changes` + `build` + `ci-pass` end-to-end. The tag-only `docker` + `cve-check` + `release` jobs need a real GitHub event context (tag ref, Releases API, Docker Hub creds) and won't run cleanly under `act` — validate those via a real push or `gh workflow run`.
+**`make ci-run` coverage gap.** `act push` exercises `changes` + `build` + `ci-pass` end-to-end. The tag-only `docker` + `cve-check` + `release` jobs need a real GitHub event context (tag ref, Releases API, GHCR / `GITHUB_TOKEN` with `packages: write`) and won't run cleanly under `act` — validate those via a real push or `gh workflow run`.
 
 **Security stack: OWASP dependency-check + Trivy only — do NOT propose re-adding Snyk.** Maven dep CVEs are covered by OWASP DC (`cve-check` job, weekly cron + tag pushes, NVD-backed). Source/config vulns + secrets are covered by Trivy filesystem scan (`build` job, informational). Built-image vulns are covered by Trivy image scan (`docker` job, CRITICAL/HIGH blocking gate). The Snyk GitHub App was intentionally removed — it was account-level (read access to source), gated nothing, and 100% overlapped OWASP DC on Maven deps. If a future analysis suggests adding Snyk, decline with this reasoning.
 
@@ -101,7 +101,10 @@ A separate [`cleanup-runs.yml`](.github/workflows/cleanup-runs.yml) prunes old w
 
 ### Required secrets
 
-`DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Settings → Secrets and variables → Actions; used only by the `docker` job). `NVD_API_KEY` is OPTIONAL — without it the `cve-check` job still works but NVD lookups are rate-limited. `GITHUB_TOKEN` is auto-provisioned.
+- **`GITHUB_TOKEN`** — auto-provisioned by GitHub Actions; used by the `docker` job (GHCR publish, scoped via `permissions: packages: write`) and the `release` job (GitHub Release upload, scoped via `permissions: contents: write`). No manual configuration needed.
+- **`NVD_API_KEY`** — OPTIONAL secret (Settings → Secrets and variables → Actions). Without it the `cve-check` job still works but NVD lookups are rate-limited. Routed via `~/.m2/settings.xml`, never argv.
+
+The legacy `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` pair is no longer needed — the project publishes to GHCR (`ghcr.io/<owner>/<repo>/apacheds-ad`) via `GITHUB_TOKEN`. Delete those secrets from the repo if they're still set.
 
 ## Upgrade Backlog
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,14 @@ APP_NAME           := ldap-server
 CURRENTTAG         := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 
 # === Docker image coordinates (mirror .env.example) ===
-DOCKER_REGISTRY    ?= registry-1.docker.io
+# Default registry: ghcr.io. DOCKER_LOGIN is your GitHub username; the
+# canonical GHCR path for this project is
+# `ghcr.io/<owner>/ldap-server/apacheds-ad` (repo-namespace) — set
+# DOCKER_LOGIN=<owner>/ldap-server for a local `make image-push` that
+# matches what CI publishes. The bare-namespace form
+# `ghcr.io/<owner>/apacheds-ad` requires a PAT with `write:packages`
+# scope (GITHUB_TOKEN cannot publish to user-namespace).
+DOCKER_REGISTRY    ?= ghcr.io
 DOCKER_LOGIN       ?=
 IMAGE_NAME         ?= apacheds-ad
 IMAGE_TAG          ?= latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # ldap-server — In-Memory LDAP Server (Apache Directory)
 
-Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0.AM27 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on Docker Hub ([`andriykalashnykov/apacheds-ad`](https://hub.docker.com/r/andriykalashnykov/apacheds-ad)) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 21 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
+Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0.AM27 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on [GHCR](https://github.com/AndriyKalashnykov/ldap-server/pkgs/container/ldap-server%2Fapacheds-ad) (`ghcr.io/andriykalashnykov/ldap-server/apacheds-ad`) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 21 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
 
 > This is a fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server) — every Java change lives upstream; the fork adds the Docker pipeline, Makefile, hardened CI, and Renovate. Java package `com.github.kwart.ldap` is intentionally kept aligned with upstream so future syncs stay clean diffs.
 
@@ -119,11 +119,11 @@ java -Djavax.net.debug=ssl \
 
 ## Docker
 
-Pre-built images are published to Docker Hub on every `v*` git tag:
+Pre-built images are published to [GHCR](https://ghcr.io) on every `v*` git tag:
 
 ```bash
-docker pull andriykalashnykov/apacheds-ad:latest
-docker run -it --rm -p 10389:10389 andriykalashnykov/apacheds-ad:latest
+docker pull ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
+docker run -it --rm -p 10389:10389 ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
 
 Mount your own `.ldif` files to seed custom entries:
@@ -132,7 +132,7 @@ Mount your own `.ldif` files to seed custom entries:
 docker run -it --rm \
   -v "$PWD/ldif:/ldap/ldif/" \
   -p 10389:10389 \
-  andriykalashnykov/apacheds-ad:latest
+  ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
 
 Or build locally:
@@ -143,7 +143,7 @@ make image-smoke-test    # boot the image, wait for HEALTHCHECK = healthy
 make image-run           # interactive run with $(LDIF_DIR) bind-mounted
 ```
 
-The runtime image is `eclipse-temurin:21-jre`-based, runs as a non-root user (UID 10001), and ships a TCP HEALTHCHECK that probes `localhost:${APP_INTERNAL_PORT}` via bash `/dev/tcp` — no `curl` / `nc` / `wget` in the image.
+The runtime image is `eclipse-temurin:21-jre-alpine`-based (~41 MB `/usr`, Trivy-clean at switch time, no Go binaries), runs as a non-root user (UID 10001), and ships a TCP HEALTHCHECK that probes `localhost:${APP_INTERNAL_PORT}` via busybox `nc -z` — no `curl` / `bash` / `wget` install needed.
 
 ## Available Make Targets
 
@@ -189,9 +189,9 @@ Every operator-tunable value is sourced from env vars with `?=` fallbacks in the
 
 | Variable | Default | Used by |
 |----------|---------|---------|
-| `DOCKER_REGISTRY` | `registry-1.docker.io` | `docker-login`, `image-push` |
-| `DOCKER_LOGIN` | _(unset)_ | tags `${DOCKER_LOGIN}/${IMAGE_NAME}:${IMAGE_TAG}` |
-| `DOCKER_PWD` | _(unset; gitignored `.env` only)_ | piped to `docker login --password-stdin` — NEVER on argv |
+| `DOCKER_REGISTRY` | `ghcr.io` | `docker-login`, `image-push` |
+| `DOCKER_LOGIN` | _(unset)_ | tags `${DOCKER_LOGIN}/${IMAGE_NAME}:${IMAGE_TAG}` — set to `<owner>/ldap-server` for the GHCR repo-namespace path |
+| `DOCKER_PWD` | _(unset; gitignored `.env` only)_ | piped to `docker login --password-stdin` — NEVER on argv. For GHCR locally, use a GitHub PAT with `write:packages` scope |
 | `IMAGE_NAME` | `apacheds-ad` | image-name segment |
 | `IMAGE_TAG` | `latest` | image-tag segment |
 | `JAR_PATH` | `target/ldap-server.jar` | `run-jar` |
@@ -211,7 +211,7 @@ GitHub Actions runs on every push to `master`, every `v*` git tag, every pull re
 | `build` | code-changing events + every tag | Provisions Java 21 + Maven 3.9.16 via `jdx/mise-action`, restores `~/.m2` from `actions/cache`, runs `make ci` (alignment guards + lint + test + package), Trivy filesystem scan (informational), uploads `target/ldap-server.jar` as an artifact |
 | `cve-check` | tag pushes + weekly cron + dispatch | OWASP dependency-check via `mvn org.owasp:dependency-check-maven:check`; NVD DB cached at `~/.m2/repository/org/owasp/dependency-check-data` for fast warm starts. NVD API key optional |
 | `release` | push to master OR `v*` tag | Downloads the JAR, recreates the `latest` GitHub Release via `softprops/action-gh-release` |
-| `docker` | `v*` tag only | Build image for scan → Trivy CRITICAL/HIGH image scan → `make image-smoke-test` → `make e2e` (LDAP bind + search) → log in to Docker Hub → push single-arch `linux/amd64` image with `flavor: latest=true`. Every gate blocks the push |
+| `docker` | `v*` tag only | Build image for scan → Trivy CRITICAL/HIGH image scan → `make image-smoke-test` → `make e2e` (LDAP bind + search) → log in to GHCR (`${{ github.actor }}` + auto-provisioned `GITHUB_TOKEN`; job has `packages: write`) → push single-arch `linux/amd64` image to `ghcr.io/<owner>/ldap-server/apacheds-ad` with `flavor: latest=true`. Every gate blocks the push |
 | `ci-pass` | always | `if: always() && contains(needs.*.result, 'failure')` — single aggregator for branch protection |
 
 Every action is SHA-pinned (verified via `gh api …/git/refs/tags`). A separate [`cleanup-runs.yml`](.github/workflows/cleanup-runs.yml) prunes old workflow runs and caches from deleted branches weekly via the native `gh` CLI.
@@ -222,10 +222,8 @@ Configure under **Settings → Secrets and variables → Actions**.
 
 | Name | Type | Used by | How to obtain |
 |------|------|---------|---------------|
-| `DOCKERHUB_USERNAME` | Secret | `docker` job — image push | Your Docker Hub account name |
-| `DOCKERHUB_TOKEN` | Secret | `docker` job — image push | Docker Hub → Account Settings → Personal access tokens |
 | `NVD_API_KEY` | Secret (optional) | `cve-check` job — raises NVD lookup rate limit | Free API key from [NIST NVD](https://nvd.nist.gov/developers/request-an-api-key); routed via `~/.m2/settings.xml`, never via argv |
-| `GITHUB_TOKEN` | _(auto-provisioned)_ | `release` + `cleanup-runs` jobs | GitHub injects automatically |
+| `GITHUB_TOKEN` | _(auto-provisioned)_ | `docker` (GHCR publish, `packages: write`), `release` (GitHub Release, `contents: write`), `cleanup-runs` | GitHub injects automatically |
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.github.andriykalashnykov</groupId>
     <artifactId>ldap-server</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <name>ldap-server</name>


### PR DESCRIPTION
## Summary

Migrate image publishing from Docker Hub to GitHub Container Registry (GHCR), eliminating the renewable-PAT secret class entirely (the 2021-dated DOCKERHUB_TOKEN had expired and blocked v1.1.1's image push despite every CVE gate passing).

## Changes

**Workflow** (`.github/workflows/build-test-push.yml`):
- `docker` job adds `packages: write` permission (scoped to that job only).
- `docker/metadata-action` `images` → `ghcr.io/${{ github.repository }}/apacheds-ad` (repo-namespace path; required for `GITHUB_TOKEN` to publish — user-namespace `ghcr.io/<owner>/<pkg>` would need a PAT with `write:packages`).
- `docker/login-action` → `registry: ghcr.io`, `username: ${{ github.actor }}`, `password: ${{ secrets.GITHUB_TOKEN }}`.

**Makefile + .env.example**:
- `DOCKER_REGISTRY` default `registry-1.docker.io` → `ghcr.io`.
- Comments expanded with GHCR repo-namespace guidance for local `make image-push` parity.

**Docs**:
- CLAUDE.md fork-identity sentence, docker-job description, required-secrets section all rewritten; `DOCKERHUB_*` secrets declared obsolete (remove from the repo).
- README.md Hero description, Docker section pull/run examples, Configuration table, CI Required-Secrets table all rewritten.
- CHANGELOG.md `[1.1.2]` entry documents the migration; `[1.1.1]` gains a 'superseded by 1.1.2' note.

**Version bump** (`pom.xml`): 1.1.1 → 1.1.2. Once merged, cut `v1.1.2` to publish the first GHCR image.

## Migration impact for consumers

The legacy Docker Hub image `andriykalashnykov/apacheds-ad` will not receive further updates. New image path starting at v1.1.2:

```bash
docker pull ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
```

## Test plan

- [x] `make ci` BUILD SUCCESS (8/8 tests)
- [x] YAML validates clean
- [x] No remaining `docker.io` / `DOCKERHUB_*` references in workflow / Makefile / .env.example / Dockerfile (only in CLAUDE.md, deliberately, in the 'obsolete — delete from repo' note)