### PR TITLE
chore(renovate): /renovate review fixes + make renovate-validate

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,11 +2,11 @@
 # CI also reads it via jdx/mise-action.
 
 [tools]
-# Java 21 LTS — ApacheDS 2.0.0-M24 (2018) targets bytecode 1.8 (pom.xml
-# `maven.compiler.source`), but the JDK that compiles + runs tests can be
-# any modern release. Verified test-pass against JDK 18, 21, and 25.
-# renovate: datasource=java-version depName=java
+# Java 21 LTS — `maven.compiler.source=21` in pom.xml matches.
+# Verified test-pass on JDK 21. Tracked natively by Renovate's mise
+# manager (no `# renovate:` annotation needed — the mise manager doesn't
+# consult inline comments; an annotation here would be dead text per the
+# /renovate skill rule).
 java = "temurin-21.0.11+10.0.LTS"
 
-# renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.16"

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ ci: deps check-java-alignment check-maven-alignment lint test package
 #ci-run: @ Run the GitHub Actions workflow locally via act
 # NOTE: act exercises the `changes`, `build`, and `ci-pass` jobs cleanly. The
 # `release` job needs a real GitHub Releases API context and the `docker` job
-# needs Docker Hub credentials + a tag ref — neither is reachable under `act`.
+# needs GHCR auth + a tag ref — neither is reachable under `act`.
 # For tag-only paths, validate via a real push or `gh workflow run`.
 ci-run:
 	@command -v act >/dev/null 2>&1 || { echo "Error: act required. Install via https://github.com/nektos/act"; exit 1; }
@@ -258,6 +258,23 @@ ci-run:
 		--artifact-server-port "$$ACT_PORT" \
 		--artifact-server-path "$$ARTIFACT_PATH"
 
+#renovate-validate: @ Validate renovate.json against the live Renovate schema (npx --yes renovate@latest)
+# `renovate@latest` (NOT bare `renovate`) avoids the npx-cache stale-binary
+# trap where a months-old cached package rejects current-schema fields like
+# `managerFilePatterns`. Uses the local-platform driver so no GitHub API
+# credentials are strictly required — but exporting `GH_ACCESS_TOKEN`
+# upgrades anonymous lookups to authenticated and avoids GitHub's 60-req/hr
+# anonymous cap when chasing release notes / version metadata.
+renovate-validate:
+	@command -v npx >/dev/null 2>&1 || { echo "Error: npx (Node.js) required. Install Node 24+ via mise or the Node.js download page."; exit 1; }
+	@if [ -n "$$GH_ACCESS_TOKEN" ]; then \
+		export GITHUB_COM_TOKEN="$$GH_ACCESS_TOKEN"; \
+	else \
+		echo "Warning: GH_ACCESS_TOKEN not set; some dependency lookups may be rate-limited or fail"; \
+	fi; \
+		npx --yes renovate@latest --platform=local
+
 .PHONY: help deps deps-check check-java-alignment check-maven-alignment \
 	build test package run-jar lint cve-check clean \
-	image-build image-run image-smoke-test e2e docker-login image-push ci ci-run
+	image-build image-run image-smoke-test e2e docker-login image-push \
+	ci ci-run renovate-validate

--- a/renovate.json
+++ b/renovate.json
@@ -53,15 +53,24 @@
       "groupName": "SLF4J"
     },
     {
-      "description": "Group Maven build plugins (shade, bundle, compiler, source, javadoc, gpg, enforcer, dependency, nexus-staging) into one PR — plugin bumps don't affect application runtime.",
+      "description": "Group Maven build plugins used by this project (maven-shade-plugin, maven-compiler-plugin, exec-maven-plugin, maven-bundle-plugin) plus the OWASP dependency-check plugin into one PR — plugin bumps don't affect application runtime.",
       "matchManagers": ["maven"],
       "matchPackageNames": [
         "/^org\\.apache\\.maven\\.plugins:/",
         "/^org\\.apache\\.felix:maven-bundle-plugin/",
         "/^org\\.codehaus\\.mojo:exec-maven-plugin/",
-        "/^org\\.sonatype\\.plugins:/"
+        "/^org\\.owasp:dependency-check-maven/"
       ],
       "groupName": "Maven plugins"
+    },
+    {
+      "description": "Group JUnit 5 Jupiter bumps — the BOM, jupiter, and jupiter-params ship together and must move in lockstep to keep Surefire's JUnit Platform Provider happy.",
+      "matchManagers": ["maven"],
+      "matchPackageNames": [
+        "/^org\\.junit:/",
+        "/^org\\.junit\\.jupiter:/"
+      ],
+      "groupName": "JUnit 5"
     }
   ]
 }


### PR DESCRIPTION
/renovate review against the live skill rules. `npx renovate --platform=local` on the resulting config tracks **47 deps across 4 managers** (dockerfile/github-actions/maven/mise) with zero validationError.

## Findings table

| Severity | File | Issue | Fix |
|---|---|---|---|
| **HIGH** | `.mise.toml` | Two `# renovate:` annotations were DEAD TEXT — native mise manager doesn't consult inline comments. Per skill §".mise.toml — DO NOT ADD ONE", these mislead future readers into adding a duplicate-tracking custom.regex. | Replaced with plain doc comments that explicitly note mise-manager coverage |
| MEDIUM | `renovate.json` | OWASP `dependency-check-maven` pinned in `<pluginManagement>` was not covered by any group rule | Added `/^org\.owasp:dependency-check-maven/` to the "Maven plugins" group |
| MEDIUM | `renovate.json` | JUnit 5 triplet (`junit-bom`, `junit-jupiter`, `junit-jupiter-params`) ungrouped — would produce 3 PRs per JUnit release | Added a "JUnit 5" group rule |
| LOW | `renovate.json` | "Maven plugins" group description named plugins not in this fork (`enforcer`/`dependency`/`javadoc`/`gpg`/`source`/`nexus-staging`) | Trimmed to the four plugins the project actually carries |
| HIGH | `Makefile` | No `renovate-validate` target | Added canonical `npx --yes renovate@latest --platform=local` recipe with `export` form for `GH_ACCESS_TOKEN -> GITHUB_COM_TOKEN` (argv-clean per the secret-in-argv policy) |

## Cross-manager grouping audit

Nothing to do. `java` and `maven` are pinned only in `.mise.toml` (mise manager). pom.xml's `maven.compiler.source=21` is a build property, not a Renovate-tracked dep. No duplicate tracking, no hard ordering constraint between manager-owned files.

## Test plan

- [x] `make renovate-validate` — zero validationError, 47 deps tracked
- [x] `make ci` BUILD SUCCESS (8/8 tests including reactivated StartTlsTest)