### PR TITLE
chore(all): upgrade Java 21 LTS -> 25 LTS

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,11 +2,12 @@
 # CI also reads it via jdx/mise-action.
 
 [tools]
-# Java 21 LTS — `maven.compiler.source=21` in pom.xml matches.
-# Verified test-pass on JDK 21. Tracked natively by Renovate's mise
-# manager (no `# renovate:` annotation needed — the mise manager doesn't
-# consult inline comments; an annotation here would be dead text per the
-# /renovate skill rule).
-java = "temurin-21.0.11+10.0.LTS"
+# Java 25 LTS — `maven.compiler.source=25` in pom.xml matches, and the
+# `check-java-alignment` guard cross-checks this major against both
+# Dockerfile FROM lines. Verified test-pass on JDK 25. Tracked natively by
+# Renovate's mise manager (no `# renovate:` annotation needed — the mise
+# manager doesn't consult inline comments; an annotation here would be dead
+# text per the /renovate skill rule).
+java = "temurin-25.0.3+9.0.LTS"
 
 maven = "3.9.16"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Single-JAR, in-memory LDAP server built on top of **ApacheDS 2.0.0.AM27**, inten
 
 ## Build & test
 
-JDK 21 LTS + Maven 3.9.x, both pinned in [`.mise.toml`](.mise.toml). `make deps` installs mise on first run, then `mise install` provisions the toolchain.
+JDK 25 LTS + Maven 3.9.x, both pinned in [`.mise.toml`](.mise.toml). `make deps` installs mise on first run, then `mise install` provisions the toolchain.
 
 - Bootstrap toolchain: `make deps` (one-time mise + Java/Maven install).
 - Full local CI: `make ci` → `deps → check-java-alignment → check-maven-alignment → lint → test → package`. The two alignment guards fail fast when the Java major in `.mise.toml` drifts from the Dockerfile `FROM` lines, or the Maven minor drifts from the build-stage tag.
@@ -21,7 +21,7 @@ JDK 21 LTS + Maven 3.9.x, both pinned in [`.mise.toml`](.mise.toml). `make deps`
 - Run the built jar: `java -jar target/ldap-server.jar [options] [LDIFs...]` — see `--help` for the full CLI (includes `--admin-password`, `--ssl-*`, `--allow-anonymous`).
 - CVE scan: `make cve-check` (OWASP dependency-check; ~2 GB NVD cold start, `NVD_API_KEY` strongly recommended).
 
-`pom.xml` sets `maven.compiler.source=21` (matches the `eclipse-temurin:21-jre` runtime). AM27 ships bytecode 52 (Java 8) but the consumer can target whatever runtime it deploys on. Dependency bumps are handled by **Renovate** — there is **no Maven Central publishing** in this fork (the upstream `release` profile with GPG signing, `nexus-staging-maven-plugin`, and the `[1.8,1.9)` Java enforcer was removed; re-add from upstream only if Central publishing is ever wanted).
+`pom.xml` sets `maven.compiler.source=25` (matches the `eclipse-temurin:25-jre` runtime). AM27 ships bytecode 52 (Java 8) but the consumer can target whatever runtime it deploys on. Dependency bumps are handled by **Renovate** — there is **no Maven Central publishing** in this fork (the upstream `release` profile with GPG signing, `nexus-staging-maven-plugin`, and the `[1.8,1.9)` Java enforcer was removed; re-add from upstream only if Central publishing is ever wanted).
 
 ## Architecture
 
@@ -64,8 +64,8 @@ Each test starts a real LDAP server on `10389` (and a TLS port for TLS variants)
 
 Multi-stage `Dockerfile`, **builds from source** (does not download a released JAR):
 
-- **Builder**: `maven:3.9-eclipse-temurin-21` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
-- **Runtime**: `eclipse-temurin:21-jre-alpine`. Non-root user UID/GID 10001 (busybox `addgroup`/`adduser`, no home, `/sbin/nologin`), owns `/ldap`. No `apk add` in the runtime layer.
+- **Builder**: `maven:3.9-eclipse-temurin-25` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
+- **Runtime**: `eclipse-temurin:25-jre-alpine`. Non-root user UID/GID 10001 (busybox `addgroup`/`adduser`, no home, `/sbin/nologin`), owns `/ldap`. No `apk add` in the runtime layer.
 - **HEALTHCHECK**: `nc -z ${HEALTHCHECK_HOST} ${APP_INTERNAL_PORT}` (busybox netcat) — probes the LDAP TCP listener since ApacheDS exposes no HTTP endpoint. The flag *timings* are literal because Docker's parser does not expand ARG/ENV in those slots; the CMD's `${VAR}` honor `docker run -e ...` overrides.
 - **CMD** (shell form): `java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/`. Mount a directory of `.ldif` files into `/ldap/ldif/` to seed entries.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This repo is a **fork of [intoolswetrust/ldap-server](https://github.com/intools
 
 ## Build, run, test
 
-JDK 21 LTS + Maven 3.9.16, both pinned in [`.mise.toml`](.mise.toml). `make deps` installs mise on first run, then `mise install` provisions the toolchain.
+JDK 25 LTS + Maven 3.9.16, both pinned in [`.mise.toml`](.mise.toml). `make deps` installs mise on first run, then `mise install` provisions the toolchain.
 
 ```bash
 make deps                                            # one-time mise + Java/Maven bootstrap
@@ -25,7 +25,7 @@ java -jar ./target/ldap-server.jar --help            # full CLI flag list (inclu
 
 `make ci` chains `deps → check-java-alignment → check-maven-alignment → lint → test → package`. The two alignment guards fail fast when the Java major in `.mise.toml` drifts from the Dockerfile `FROM` lines, or when the Maven minor drifts from the build-stage tag — silent toolchain desync is otherwise a recurring foot-gun on Renovate split-PR days. Both guards are mutation-tested (proven to go RED on intentional desync).
 
-`pom.xml` sets `maven.compiler.source=21` (matches the Dockerfile runtime `eclipse-temurin:21-jre`). AM27 itself ships bytecode 52 (Java 8) but our application can target whatever runtime we deploy on — the dep's floor does not constrain the consumer's target. The `release` profile that enforced `[1.8,1.9)` was removed in this fork; re-add it from upstream if Maven Central publishing is ever wanted.
+`pom.xml` sets `maven.compiler.source=25` (matches the Dockerfile runtime `eclipse-temurin:25-jre`). AM27 itself ships bytecode 52 (Java 8) but our application can target whatever runtime we deploy on — the dep's floor does not constrain the consumer's target. The `release` profile that enforced `[1.8,1.9)` was removed in this fork; re-add it from upstream if Maven Central publishing is ever wanted.
 
 ### Tests
 
@@ -61,8 +61,8 @@ Entry point is `com.github.kwart.ldap.LdapServer#main`, declared as the shaded J
 
 Multi-stage Dockerfile, builds from source — does NOT download a released JAR.
 
-- **Builder**: `maven:3.9-eclipse-temurin-21` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
-- **Runtime**: `eclipse-temurin:21-jre-alpine` (alpine variant; ~41 MB `/usr`, no Go binaries to drag in stdlib CVEs, Trivy-clean at time of switch). Non-root user UID/GID 10001 (created via busybox `addgroup`/`adduser`, no home, `/sbin/nologin` shell). Owns `/ldap`.
+- **Builder**: `maven:3.9-eclipse-temurin-25` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
+- **Runtime**: `eclipse-temurin:25-jre-alpine` (alpine variant; ~41 MB `/usr`, no Go binaries to drag in stdlib CVEs, Trivy-clean at time of switch). Non-root user UID/GID 10001 (created via busybox `addgroup`/`adduser`, no home, `/sbin/nologin` shell). Owns `/ldap`.
 - **HEALTHCHECK**: `nc -z ${HEALTHCHECK_HOST} ${APP_INTERNAL_PORT}` — busybox netcat is bundled with alpine; no extra package install needed. Probes the LDAP TCP listener since ApacheDS exposes only the LDAP protocol (no HTTP `/healthz`). The previous `bash -c 'exec 3<>/dev/tcp/...'` form was Ubuntu-base specific; alpine's busybox sh has no `/dev/tcp`. **No `apk add` in the runtime layer.**
 - **`HEALTHCHECK` flag timings are LITERAL** (`--interval=30s --timeout=3s --start-period=20s --retries=3`) because Docker's parser does NOT expand ARG/ENV in those slots. The CMD's `${VAR}` expand at container start, so `HEALTHCHECK_HOST` and `APP_INTERNAL_PORT` honor `docker run -e ...` overrides.
 - **CMD**: shell form so `${APP_INTERNAL_PORT}` is honored — `java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@
 # =============================================================================
 # Build stage — compile shaded JAR from source
 # =============================================================================
-# The official Maven + Temurin 21 image — mvn + JDK in one layer.
+# The official Maven + Temurin 25 image — mvn + JDK in one layer.
 # Renovate-tracked via the `dockerfile` manager; digest pin keeps the
 # build reproducible across registry-tag retags.
-FROM maven:3.9-eclipse-temurin-21@sha256:1bb51c5ed28b95aef2bc7b46bff6940da43747cdaf838ce4afc2081ce9403750 AS build
+FROM maven:3.9-eclipse-temurin-25@sha256:52766e42de54a9a52bd72e500db1d8e8818133b79550586aa7ddac10c6e4fc84 AS build
 
 WORKDIR /workspace
 
@@ -26,7 +26,7 @@ RUN test -s /workspace/target/ldap-server.jar
 # =============================================================================
 # Runtime stage — slim JRE, non-root, env-driven tunables
 # =============================================================================
-FROM eclipse-temurin:21.0.11_10-jre-alpine@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:c707c0d18cb9e8556380719f80d96a7529d0746fbb42143893949b98ed2f8943
 
 # === Operator tunables (slot 2 — ARG defaults; see configuration.md) ===
 ARG APP_INTERNAL_PORT=10389

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # ldap-server — In-Memory LDAP Server (Apache Directory)
 
-Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0.AM27 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on [GHCR](https://github.com/AndriyKalashnykov/ldap-server/pkgs/container/ldap-server%2Fapacheds-ad) (`ghcr.io/andriykalashnykov/ldap-server/apacheds-ad`) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 21 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
+Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0.AM27 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on [GHCR](https://github.com/AndriyKalashnykov/ldap-server/pkgs/container/ldap-server%2Fapacheds-ad) (`ghcr.io/andriykalashnykov/ldap-server/apacheds-ad`) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 25 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
 
 > This is a fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server) — every Java change lives upstream; the fork adds the Docker pipeline, Makefile, hardened CI, and Renovate. Java package `com.github.kwart.ldap` is intentionally kept aligned with upstream so future syncs stay clean diffs.
 
@@ -13,21 +13,21 @@ Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://dir
 
 | Component | Technology |
 |-----------|------------|
-| Language | Java 21 LTS (source + bytecode target 21; matches `eclipse-temurin:21-jre` runtime) |
+| Language | Java 25 LTS (source + bytecode target 25; matches `eclipse-temurin:25-jre` runtime) |
 | LDAP engine | Apache Directory Server 2.0.0.AM27 |
 | Build | Maven 3.9.16 + `maven-shade-plugin` 3.6.2 (single runnable JAR) |
 | CLI parser | JCommander 1.82 (`IUsageFormatter`-based) |
 | Logging | SLF4J 2.0.18 + `slf4j-simple` (ServiceLoader binding) |
 | Tests | JUnit 5 Jupiter 6.1.0 via `junit-bom` (8 tests, all passing — incl. StartTLS over TLSv1.3) |
-| Container | Multi-stage Dockerfile: `maven:3.9-eclipse-temurin-21` → `eclipse-temurin:21-jre` (both `@sha256:`-digest-pinned), non-root UID 10001, TCP HEALTHCHECK |
-| Version manager | [mise](https://mise.jdx.dev/) (`.mise.toml` pins Java 21 LTS + Maven 3.9.16) |
+| Container | Multi-stage Dockerfile: `maven:3.9-eclipse-temurin-25` → `eclipse-temurin:25-jre` (both `@sha256:`-digest-pinned), non-root UID 10001, TCP HEALTHCHECK |
+| Version manager | [mise](https://mise.jdx.dev/) (`.mise.toml` pins Java 25 LTS + Maven 3.9.16) |
 | Dep management | Renovate (Maven + GitHub Actions + Dockerfile + `.mise.toml`) |
 | CI | GitHub Actions — paths-filter changes detector + `jdx/mise-action` + Trivy image scan + TCP smoke test |
 
 ## Quick Start
 
 ```bash
-make deps          # install Java 21 + Maven via mise (one-time, asks you to activate shell)
+make deps          # install Java 25 + Maven via mise (one-time, asks you to activate shell)
 make ci            # lint + test + package -> target/ldap-server.jar
 make run-jar       # start the server on 0.0.0.0:10389 with bundled LDIF
 # Bind URL:  ldap://127.0.0.1:10389/dc=ldap,dc=example
@@ -55,7 +55,7 @@ ldapsearch -x -H ldap://127.0.0.1:10389 -D 'uid=admin,ou=system' -w secret \
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Git](https://git-scm.com/) | any | Source control |
 | [mise](https://mise.jdx.dev/) | latest | Pins Java + Maven from [`.mise.toml`](.mise.toml); `make deps` installs it on first run |
-| [JDK (Temurin)](https://adoptium.net/) | 21 LTS | Auto-installed by `mise install` |
+| [JDK (Temurin)](https://adoptium.net/) | 25 LTS | Auto-installed by `mise install` |
 | [Maven](https://maven.apache.org/) | 3.9.11 | Auto-installed by `mise install` |
 | [Docker](https://www.docker.com/) | 20.10+ | Optional — required only for `make image-build` / `make image-smoke-test` |
 
@@ -143,7 +143,7 @@ make image-smoke-test    # boot the image, wait for HEALTHCHECK = healthy
 make image-run           # interactive run with $(LDIF_DIR) bind-mounted
 ```
 
-The runtime image is `eclipse-temurin:21-jre-alpine`-based (~41 MB `/usr`, Trivy-clean at switch time, no Go binaries), runs as a non-root user (UID 10001), and ships a TCP HEALTHCHECK that probes `localhost:${APP_INTERNAL_PORT}` via busybox `nc -z` — no `curl` / `bash` / `wget` install needed.
+The runtime image is `eclipse-temurin:25-jre-alpine`-based (~41 MB `/usr`, Trivy-clean at switch time, no Go binaries), runs as a non-root user (UID 10001), and ships a TCP HEALTHCHECK that probes `localhost:${APP_INTERNAL_PORT}` via busybox `nc -z` — no `curl` / `bash` / `wget` install needed.
 
 ## Available Make Targets
 
@@ -208,7 +208,7 @@ GitHub Actions runs on every push to `master`, every `v*` git tag, every pull re
 | Job | Triggers | Purpose |
 |-----|----------|---------|
 | `changes` | every event | [`dorny/paths-filter`](https://github.com/dorny/paths-filter) — doc-only PRs skip every job below |
-| `build` | code-changing events + every tag | Provisions Java 21 + Maven 3.9.16 via `jdx/mise-action`, restores `~/.m2` from `actions/cache`, runs `make ci` (alignment guards + lint + test + package), Trivy filesystem scan (informational), uploads `target/ldap-server.jar` as an artifact |
+| `build` | code-changing events + every tag | Provisions Java 25 + Maven 3.9.16 via `jdx/mise-action`, restores `~/.m2` from `actions/cache`, runs `make ci` (alignment guards + lint + test + package), Trivy filesystem scan (informational), uploads `target/ldap-server.jar` as an artifact |
 | `cve-check` | tag pushes + weekly cron + dispatch | OWASP dependency-check via `mvn org.owasp:dependency-check-maven:check`; NVD DB cached at `~/.m2/repository/org/owasp/dependency-check-data` for fast warm starts. **`NVD_API_KEY` strongly recommended** — without it the plugin's parallel NVD fetcher fails on cold cache (anonymous rate-limiting exhausts its connection pool) |
 | `release` | push to master OR `v*` tag | Downloads the JAR, recreates the `latest` GitHub Release via `softprops/action-gh-release` |
 | `docker` | `v*` tag only | Build image for scan → Trivy CRITICAL/HIGH image scan → `make image-smoke-test` → `make e2e` (LDAP bind + search) → log in to GHCR (`${{ github.actor }}` + auto-provisioned `GITHUB_TOKEN`; job has `packages: write`) → push single-arch `linux/amd64` image to `ghcr.io/<owner>/ldap-server/apacheds-ad` with `flavor: latest=true`. Every gate blocks the push |

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.apache.ds>2.0.0.AM27</version.org.apache.ds>
         <version.junit>6.1.0</version.junit>
-        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <exec.mainClass>com.github.kwart.ldap.LdapServer</exec.mainClass>
     </properties>


### PR DESCRIPTION
## Summary

Coordinated **Java 21 LTS → 25 LTS** bump across every touchpoint the `check-java-alignment` guard cross-checks (so the majors stay in lockstep):

| Touchpoint | 21 → 25 |
|---|---|
| `.mise.toml` | `temurin-21.0.11+10.0.LTS` → `temurin-25.0.3+9.0.LTS` |
| Dockerfile build base | `maven:3.9-eclipse-temurin-21` → `-25` (digest `52766e…`) |
| Dockerfile runtime | `eclipse-temurin:21.0.11_10-jre-alpine` → `25.0.3_9-jre-alpine` (digest `c707c0…`) |
| `pom.xml` | `maven.compiler.source` 21 → 25 |
| docs (CLAUDE/README/AGENTS) | Java 21 → 25 references |

**Subsumes Renovate PR #19**, which bumped only the runtime `FROM` and so failed the alignment guard (`Java major versions disagree: .mise.toml 21`).

## Verification
- Local JDK 25 (Temurin-25.0.3+9): `check-java-alignment` passes (all three majors = 25); `make test` **8/8 green** incl. `StartTlsTest`.
- Real GitHub CI on this PR is the authoritative gate (clean runner). *(I relied on it rather than another local `make ci-run` because StartTlsTest's TLS handshake intermittently hangs locally under back-to-back-run port contention — it's reliable on CI runners.)*

## Notes (pre-existing, not introduced here)
- JCommander deprecation note in `ExtCommander.java` (also present on JDK 21).
- `caffeine-2.9.3` `sun.misc.Unsafe` warning (transitive via ApacheDS AM27) — Java 23+ flags it terminally deprecated; informational, build succeeds. Worth watching as a future-JDK backlog item.