### PR TITLE
release: v1.2.0 — Java 25 LTS + CI/deprecation fixes

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -177,7 +177,13 @@ jobs:
     permissions:
       contents: write       # create + replace the `latest` GitHub Release
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download shaded JAR
+        # !env.ACT for parity with the upload steps — download-artifact v5+
+        # speaks the same blob protocol act's built-in artifact server can't
+        # serve. release is push-to-master/tag-gated (won't run under act on a
+        # feature branch), but this keeps all artifact steps consistent.
+        if: ${{ !env.ACT }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ldap-server-jar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ The fork inherits the upstream Java code from
 fork-owned changes (Docker pipeline, Makefile, hardened CI, Renovate config,
 and dependency / source migrations driven by the fork) are recorded below.
 
+## [1.2.0] — 2026-05-31
+
+Minor bump (not a patch): the runtime Java baseline moves 21 → 25, a
+consumer-visible requirement change — a `maven.compiler.target=25` JAR
+will not run on a JVM older than 25.
+
+### Changed
+
+- **Java 21 LTS → 25 LTS (coordinated across every alignment touchpoint).**
+  The `check-java-alignment` guard requires `.mise.toml`, the Dockerfile
+  build base, and the Dockerfile runtime base to share one Java major,
+  so all three moved in lockstep:
+  - `.mise.toml` — `temurin-21.0.11+10.0.LTS` → `temurin-25.0.3+9.0.LTS`.
+  - `Dockerfile` build base — `maven:3.9-eclipse-temurin-21` → `-25`.
+  - `Dockerfile` runtime base — `eclipse-temurin:21.0.11_10-jre-alpine`
+    → `25.0.3_9-jre-alpine` (alpine 3.23.4; `/usr` ~26 MB; Trivy
+    CRITICAL/HIGH clean on the base and the shaded JAR, verified
+    2026-05-31).
+  - `pom.xml` — `maven.compiler.source` 21 → 25.
+  Verified on Temurin 25.0.3+9: alignment guard green, all 8 JUnit tests
+  pass (incl. `StartTlsTest`), and the built image is healthy + passes the
+  LDAP bind/search e2e.
+- **`actions/upload-artifact` tracks latest instead of being pinned at
+  v4.x.** v5+ uses a blob-upload protocol `nektos/act`'s built-in artifact
+  server cannot decode (v6 → `Error unauthorized`; v7 → `CreateArtifact:
+  unknown field "mime_type"`), which broke `make ci-run`. Instead of
+  pinning the action (and stranding the repo on the Node-20-deprecated v4
+  runtime), the artifact steps now gate on `if: ${{ !env.ACT }}` — `act`
+  skips them, real GitHub Actions runs them.
+
+### Fixed
+
+- **`release` job no longer fails on doc-only pushes.** It was gated on
+  `!failure() && !cancelled()`, which treats a *skipped* `build` (doc-only
+  push, where the `changes` filter skips it) as OK — so `release` ran with
+  no artifact and failed at `download-artifact` (`Artifact not found for
+  name: ldap-server-jar`), turning `ci-pass` red on `master`. Now gated on
+  `needs.build.result == 'success'`, so it skips cleanly when `build` skips.
+- **`ExtCommander` no longer calls a deprecated JCommander constructor.**
+  `JCommander(Object, String...)` is deprecated (it parses in the ctor);
+  `ExtCommander(Object, String...)` now uses the non-deprecated
+  `super(object)` + explicit `parse(args)` — behaviourally identical, no
+  deprecation warning under JDK 25.
+
 ## [1.1.2] — 2026-05-31
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Entry point is `com.github.kwart.ldap.LdapServer#main`, declared as the shaded J
 Multi-stage Dockerfile, builds from source — does NOT download a released JAR.
 
 - **Builder**: `maven:3.9-eclipse-temurin-25` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
-- **Runtime**: `eclipse-temurin:25-jre-alpine` (alpine variant; ~41 MB `/usr`, no Go binaries to drag in stdlib CVEs, Trivy-clean at time of switch). Non-root user UID/GID 10001 (created via busybox `addgroup`/`adduser`, no home, `/sbin/nologin` shell). Owns `/ldap`.
+- **Runtime**: `eclipse-temurin:25-jre-alpine` (alpine variant; ~26 MB `/usr`, no Go binaries to drag in stdlib CVEs, Trivy-clean at time of switch). Non-root user UID/GID 10001 (created via busybox `addgroup`/`adduser`, no home, `/sbin/nologin` shell). Owns `/ldap`.
 - **HEALTHCHECK**: `nc -z ${HEALTHCHECK_HOST} ${APP_INTERNAL_PORT}` — busybox netcat is bundled with alpine; no extra package install needed. Probes the LDAP TCP listener since ApacheDS exposes only the LDAP protocol (no HTTP `/healthz`). The previous `bash -c 'exec 3<>/dev/tcp/...'` form was Ubuntu-base specific; alpine's busybox sh has no `/dev/tcp`. **No `apk add` in the runtime layer.**
 - **`HEALTHCHECK` flag timings are LITERAL** (`--interval=30s --timeout=3s --start-period=20s --retries=3`) because Docker's parser does NOT expand ARG/ENV in those slots. The CMD's `${VAR}` expand at container start, so `HEALTHCHECK_HOST` and `APP_INTERNAL_PORT` honor `docker run -e ...` overrides.
 - **CMD**: shell form so `${APP_INTERNAL_PORT}` is honored — `java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/`.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ make image-smoke-test    # boot the image, wait for HEALTHCHECK = healthy
 make image-run           # interactive run with $(LDIF_DIR) bind-mounted
 ```
 
-The runtime image is `eclipse-temurin:25-jre-alpine`-based (~41 MB `/usr`, Trivy-clean at switch time, no Go binaries), runs as a non-root user (UID 10001), and ships a TCP HEALTHCHECK that probes `localhost:${APP_INTERNAL_PORT}` via busybox `nc -z` — no `curl` / `bash` / `wget` install needed.
+The runtime image is `eclipse-temurin:25-jre-alpine`-based (~26 MB `/usr`, Trivy-clean at switch time, no Go binaries), runs as a non-root user (UID 10001), and ships a TCP HEALTHCHECK that probes `localhost:${APP_INTERNAL_PORT}` via busybox `nc -z` — no `curl` / `bash` / `wget` install needed.
 
 ## Available Make Targets
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.github.andriykalashnykov</groupId>
     <artifactId>ldap-server</artifactId>
-    <version>1.1.2</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>ldap-server</name>

--- a/src/main/java/com/github/kwart/ldap/ExtCommander.java
+++ b/src/main/java/com/github/kwart/ldap/ExtCommander.java
@@ -56,8 +56,13 @@ public class ExtCommander extends JCommander {
     }
 
     public ExtCommander(Object object, String... args) {
-        super(object, args);
+        // JCommander(Object, String...) is deprecated (it parses in the ctor);
+        // the non-deprecated path is construct-then-parse. super(object) only
+        // registers the object, so set the formatter before parse() and parse
+        // args explicitly — behaviourally identical to the deprecated ctor.
+        super(object);
         setUsageFormatter(new ExtUsageFormatter());
+        parse(args);
     }
 
     public ExtCommander(Object object) {


### PR DESCRIPTION
## Summary
Release **v1.2.0** (minor — runtime Java baseline 21→25 is consumer-visible). Bundles the Java 25 follow-up fixes:

| Fix | Detail |
|---|---|
| **ExtCommander deprecation** | Replaced deprecated `JCommander(Object, String...)` ctor with `super(object)` + explicit `parse(args)` — behaviourally identical, deprecation gone under JDK 25 (verified: recompile clean, 8/8 tests pass incl. StartTlsTest which exercises that ctor with keystore args). |
| **`release` download-artifact** | Gated on `if: ${{ !env.ACT }}` for parity with the upload steps. |
| **Stale image-size claim** | README/CLAUDE `/usr` size corrected from stale **~41 MB** (measured on 21 alpine) to the real **~26 MB** measured on `eclipse-temurin:25-jre-alpine`. |
| **CHANGELOG** | `1.2.0` entry. |
| **pom** | `1.1.2 → 1.2.0`. |

## Verification (fact-checked, no guesses)
- **Java 25 image**: `make image-build` OK → `make image-smoke-test` healthy → `make e2e` LDAP bind+search PASS; image runs Temurin 25.0.3+9.
- **Trivy CRITICAL/HIGH on the real 25 image**: **0 findings** (alpine 3.23.4 base + shaded JAR), 2026-05-31.
- **Tests**: 8/8 on JDK 25.

## After merge
Tag `v1.2.0` to trigger the `docker` job (build + Trivy CRITICAL/HIGH gate + smoke + e2e on 25) and publish the Java 25 image to GHCR.