### PR TITLE
fix(security): bc-jdk15on 1.70 → bc-jdk18on 1.84 (CVE-2024-29857/34447)

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -13,4 +13,16 @@
 
         See https://jeremylong.github.io/DependencyCheck/general/suppression.html
     -->
+    <suppress>
+        <notes><![CDATA[
+            False positive. dependency-check CPE-matches the ApacheDS packages
+            (org.apache.directory.server:* — an LDAP server) to
+            cpe:2.3:a:apache:apache_http_server, dragging in CVE-2010-1151, an
+            Apache HTTP Server mod_auth_* race condition that does not apply to
+            ApacheDS. Pinned to 2.0.0.AM27; re-evaluate (and delete or re-range)
+            when bumping past AM27.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/.*@2\.0\.0\.AM27$</packageUrl>
+        <cve>CVE-2010-1151</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.apache.ds>2.0.0.AM27</version.org.apache.ds>
         <version.junit>6.1.0</version.junit>
+        <!-- CVE override: AM27 pulls bc*-jdk15on 1.70 transitively (CVE-2024-29857
+             7.5, CVE-2024-34447 7.7). The jdk15on line ended at 1.70; the fix is
+             only in the renamed jdk18on line, so we exclude the jdk15on artifacts
+             on the apacheds deps and add jdk18on here. Removable (revert to AM27's
+             transitive) once ApacheDS ships a release on bc-jdk18on >= 1.78. -->
+        <version.org.bouncycastle>1.84</version.org.bouncycastle>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <exec.mainClass>com.github.kwart.ldap.LdapServer</exec.mainClass>
@@ -151,6 +157,12 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <!-- Drop the vulnerable bc*-jdk15on:1.70 transitives (pulls
+                     bcpkix/bcutil via apacheds-core); replaced by jdk18on below. -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -161,6 +173,33 @@
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-protocol-ldap</artifactId>
+            <exclusions>
+                <!-- Drop the vulnerable bcprov-jdk15on:1.70 transitive;
+                     replaced by jdk18on below. -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- BouncyCastle: explicit jdk18on 1.84 replacing AM27's transitive
+             bc*-jdk15on 1.70 (see version.org.bouncycastle note). bcprov is
+             needed by apacheds-protocol-ldap; bcpkix (+ bcutil) by apacheds-core. -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${version.org.bouncycastle}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${version.org.bouncycastle}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
+            <version>${version.org.bouncycastle}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
The newly-complete `cve-check` (now that NVD has a full DB + OSS Index is enabled, both via the prior fixes) caught **real CVEs ≥ 7.0** that earlier runs missed: ApacheDS AM27 pulls **`bc{prov,pkix,util}-jdk15on:1.70`** transitively, carrying **CVE-2024-29857 (7.5)** and **CVE-2024-34447 (7.7)**. v1.2.0 shipped with these.

The `jdk15on` line ended at 1.70; the fix is only in the renamed **`jdk18on`** line. So: exclude all `org.bouncycastle:*` transitives from `apacheds-core-annotations` + `apacheds-protocol-ldap`, add **`bc*-jdk18on:1.84`** directly (Renovate-tracked via `version.org.bouncycastle`). Same exclude+pin shape as the existing `mina-core` override.

Also suppresses **CVE-2010-1151** on `org.apache.directory.server:*` — a confirmed false positive (apacheds CPE-mismatched to `apache_http_server`), pinned to AM27 with a re-eval trigger.

## Verification (fact-checked)
- `dependency:tree` → **only `bc*-jdk18on:1.84`**, no `jdk15on`/1.70 anywhere.
- **All 8 tests pass on JDK 25 incl. `StartTlsTest`** (BC-backed TLS) → AM27 ↔ BC 1.84 compatible.
- Local image-build + smoke + e2e running; authoritative `cve-check` (0 findings ≥7) will be re-run via `workflow_dispatch` post-merge before cutting v1.2.1.