### PR TITLE
docs(readme): Docker section seeds with the repo's real example LDIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,24 @@ Pre-built images are published to [GHCR](https://ghcr.io) on every `v*` git tag:
 
 ```bash
 docker pull ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
-docker run -it --rm -p 10389:10389 ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
 
-Mount your own `.ldif` files to seed custom entries:
+The default entrypoint imports every `*.ldif` under `/ldap/ldif/`, which is an **empty mount point** in the image — so a plain `docker run` with no mount starts with **no directory entries**. Two ways to seed data, both using this repo's own example tree:
+
+**1. Bundled example data (no mount).** The JAR bundles [`src/main/resources/ldap-example.ldif`](src/main/resources/ldap-example.ldif) (`dc=ldap,dc=example` with `uid=jduke` / `theduke` + an `Admin` group). Override the entrypoint to run with no LDIF argument, which falls back to that bundled default:
 
 ```bash
-docker run -it --rm \
-  -v "$PWD/ldif:/ldap/ldif/" \
-  -p 10389:10389 \
+docker run -it --rm -p 10389:10389 --entrypoint java \
+  ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest \
+  -jar /ldap/ldap-server.jar -b 0.0.0.0 -p 10389
+# bind: uid=jduke,ou=Users,dc=ldap,dc=example / theduke
+```
+
+**2. Mount a directory of `.ldif` files.** Every `*.ldif` inside is imported (non-`.ldif` files are ignored). Mount this repo's `src/main/resources/` to seed the same example tree, or point at your own directory:
+
+```bash
+docker run -it --rm -p 10389:10389 \
+  -v "$PWD/src/main/resources:/ldap/ldif:ro" \
   ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
 


### PR DESCRIPTION
The Docker mount example pointed at `$PWD/ldif` (nonexistent in the repo) and the default `docker run` starts with an empty `/ldap/ldif/` — so no copy-pasted example produced data, and none referenced the repo's own `ldap-example.ldif`. Rewrote to two verified examples using the repo's example tree: (1) bundled data via entrypoint override (proven by `make e2e`), (2) mount `src/main/resources/` (verified: imports ldap-example.ldif, loads uid=jduke). Doc-only → ci-pass green.