### PR TITLE
docs(readme): document admin/user credentials + base DN in Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ docker run -it --rm -p 10389:10389 \
   ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
 
+**Connecting.** The directory's built-in administrator exists regardless of how data is seeded:
+
+| | Value |
+|---|---|
+| Admin bind DN | `uid=admin,ou=system` |
+| Admin password | `secret` — override with `--admin-password <new>` |
+| Default partition / search base | `dc=ldap,dc=example` |
+
+With the example data above there is also a regular user `uid=jduke,ou=Users,dc=ldap,dc=example` (password `theduke`). Verify a running container:
+
+```bash
+ldapsearch -x -H ldap://127.0.0.1:10389 -D 'uid=admin,ou=system' -w secret \
+  -b dc=ldap,dc=example '(objectClass=*)'
+```
+
+The admin account is the ApacheDS system administrator and is independent of the loaded LDIF — when you mount your own `.ldif`, those files define the regular entries (their own DNs and `userPassword` values) while admin stays `uid=admin,ou=system` / `secret`.
+
 Or build locally:
 
 ```bash


### PR DESCRIPTION
The Docker section seeded data but never told the reader how to connect. Added a Connecting block: admin `uid=admin,ou=system` / `secret` (override via `--admin-password`), base `dc=ldap,dc=example`, example user `jduke`/`theduke`, a verify `ldapsearch`, and the admin-is-independent-of-LDIF note. Verified live: admin-bind ldapsearch returns uid=jduke, result 0. Doc-only → ci-pass green.