### PR TITLE
feat(docs): README C4 hero diagram + mermaid-lint gate + title alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ BIND_ADDRESS       ?= 0.0.0.0
 #   make image-build APP_INTERNAL_PORT=10399
 APP_INTERNAL_PORT  ?= 10389
 
+# Mermaid CLI image for `mermaid-lint` (validates README C4 diagram). Renovate-
+# tracked via the customManager regex in renovate.json.
+# renovate: datasource=docker depName=minlag/mermaid-cli
+MERMAID_CLI_VERSION ?= 11.15.0
+
 #help: @ List available tasks
 help:
 	@echo "Usage: make COMMAND"
@@ -118,7 +123,7 @@ run-jar: package
 	java -jar "$(JAR_PATH)" "$${args[@]}" "$(LDIF_DIR)"
 
 #lint: @ Validate pom.xml + shell-script executable-bit guard
-lint: deps
+lint: deps mermaid-lint
 	@mvn -B validate
 	@# Safety check rule #8: any committed shell script must be +x or CI fails with exit 126.
 	@NONEXEC=$$(find . -maxdepth 3 -name '*.sh' -not -executable -not -path './target/*' -not -path './.git/*' 2>/dev/null); \
@@ -126,6 +131,32 @@ lint: deps
 		echo "Error: shell scripts missing +x bit:"; echo "$$NONEXEC" | sed 's/^/  /'; \
 		exit 1; \
 	fi
+
+#mermaid-lint: @ Validate Mermaid diagrams in markdown via minlag/mermaid-cli
+mermaid-lint:
+	@if [ -n "$${ACT:-}" ]; then echo "mermaid-lint: skipped under act (docker-in-docker bind-mount path mismatch); runs on real CI."; exit 0; fi
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
+	@set -euo pipefail; \
+	MD_FILES=$$(grep -lF '```mermaid' README.md CLAUDE.md AGENTS.md 2>/dev/null || true); \
+	if [ -z "$$MD_FILES" ]; then echo "No Mermaid blocks found — skipping."; exit 0; fi; \
+	IMAGE=minlag/mermaid-cli:$(MERMAID_CLI_VERSION); \
+	for attempt in 1 2 3; do \
+		if docker pull --quiet "$$IMAGE" >/dev/null 2>&1; then break; fi; \
+		if [ "$$attempt" -eq 3 ]; then echo "ERROR: docker pull $$IMAGE failed after 3 attempts"; exit 1; fi; \
+		delay=$$((attempt * 5)); echo "  ! docker pull failed (attempt $$attempt/3); retrying in $${delay}s..."; sleep "$$delay"; \
+	done; \
+	FAILED=0; \
+	for md in $$MD_FILES; do \
+		echo "Validating Mermaid blocks in $$md..."; \
+		LOG=$$(mktemp); \
+		if docker run --rm -v "$$PWD:/data:ro" "$$IMAGE" -i "/data/$$md" -o "/tmp/$$(basename $$md .md).svg" >"$$LOG" 2>&1; then \
+			echo "  ✓ All blocks rendered cleanly."; \
+		else \
+			echo "  ✗ Parse error in $$md:"; sed 's/^/    /' "$$LOG"; FAILED=$$((FAILED + 1)); \
+		fi; \
+		rm -f "$$LOG"; \
+	done; \
+	[ "$$FAILED" -eq 0 ] || { echo "mermaid-lint: $$FAILED file(s) failed"; exit 1; }
 
 #cve-check: @ OWASP dependency-check (Maven + transitive deps)
 # Uses the fully-qualified `org.owasp:dependency-check-maven:check` coordinate
@@ -286,6 +317,6 @@ renovate-validate:
 		npx --yes renovate@latest --platform=local
 
 .PHONY: help deps deps-check check-java-alignment check-maven-alignment \
-	build test package run-jar lint cve-check clean \
+	build test package run-jar lint mermaid-lint cve-check clean \
 	image-build image-run image-smoke-test e2e docker-login image-push \
 	ci ci-run renovate-validate

--- a/README.md
+++ b/README.md
@@ -3,11 +3,21 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/ldap-server)
 
-# ldap-server — In-Memory LDAP Server (Apache Directory)
+# In-Memory LDAP Server (Apache Directory) — drop-in for tests, SSO mocks & dev
 
 Single-JAR, in-memory LDAP server wrapping [Apache Directory Server](https://directory.apache.org/apacheds/) 2.0.0.AM27 — useful for integration testing, SSO simulators, and local development without standing up a real directory. The **runtime surface** exposes the LDAP protocol (default partition `dc=ldap,dc=example`) with optional LDAPS, configurable bind address / port, a swappable admin password (`uid=admin,ou=system`), and one-or-more `.ldif` files imported at boot via JCommander-driven CLI flags; the **delivery surface** ships as a self-contained Maven-shaded JAR, a multi-stage non-root Docker image on [GHCR](https://github.com/AndriyKalashnykov/ldap-server/pkgs/container/ldap-server%2Fapacheds-ad) (`ghcr.io/andriykalashnykov/ldap-server/apacheds-ad`) built from `@sha256:`-digest-pinned base images, toolchain-alignment guards keeping `.mise.toml` and `Dockerfile` in lockstep on Java 25 + Maven 3.9.16, a GitHub Actions pipeline gated by `dorny/paths-filter`, Trivy filesystem + image scans (CRITICAL/HIGH blocking on the image side), a TCP-probe smoke test, an LDAP-bind + search end-to-end gate before push, OWASP dependency-check (weekly cron + tag pushes + manual dispatch), and Renovate-managed dependencies.
 
 > This is a fork of [intoolswetrust/ldap-server](https://github.com/intoolswetrust/ldap-server) — every Java change lives upstream; the fork adds the Docker pipeline, Makefile, hardened CI, and Renovate. Java package `com.github.kwart.ldap` is intentionally kept aligned with upstream so future syncs stay clean diffs.
+
+```mermaid
+C4Context
+    title ldap-server — in-memory LDAP directory for tests, SSO mocks & dev
+    Person(client, "App / test / CI client", "Binds and searches over LDAP")
+    System(srv, "ldap-server", "ApacheDS 2.0.0.AM27, in-memory; LDAP :10389 plus optional LDAPS / StartTLS; ships as one shaded JAR or a non-root Docker image")
+    System_Ext(ldif, "LDIF seed", "Bundled ldap-example.ldif or a mounted .ldif directory, imported at boot")
+    Rel(client, srv, "bind + search", "LDAP / LDAPS")
+    Rel(ldif, srv, "seeds entries at startup")
+```
 
 ## Tech Stack
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "maven",
     "github-actions",
     "dockerfile",
-    "mise"
+    "mise",
+    "custom.regex"
   ],
   "commitMessagePrefix": "chore(all): ",
   "commitMessageAction": "update",
@@ -26,6 +27,17 @@
     "automerge": true,
     "minimumReleaseAge": "0 days"
   },
+  "customManagers": [
+    {
+      "description": "Track `# renovate: datasource=… depName=…`-annotated *_VERSION pins in the Makefile (e.g. MERMAID_CLI_VERSION).",
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: registryUrl=(?<registryUrl>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\s+[A-Z_]+\\s*\\??=\\s*(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "{{{datasource}}}"
+    }
+  ],
   "packageRules": [
     {
       "description": "Wait 3 days before automerging major updates so the wider community has a chance to surface regressions",


### PR DESCRIPTION
ship-it Stage 2 review items #1 + #2. Adds an inline Mermaid C4Context hero (canonical README #4), a `make mermaid-lint` gate (minlag/mermaid-cli 11.15.0, Renovate-tracked via a new Makefile customManager, wired into `make lint`; skips under act, runs on real CI), and aligns the H1 with the GitHub About leading clause. Verified locally: mermaid-lint clean, renovate customManager regex matches. **Real-CI build runs mermaid-lint for the first time here** (code=true since Makefile/renovate changed).