### PR TITLE
feat(docker): pre-seed ldap-example.ldif into the image /ldap/ldif/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ make image-run           # interactive run with $(LDIF_DIR) bind-mounted into /l
 make e2e                 # boot image + run AuthenticateWithSearch (LDAP bind + uid search + re-bind)
 ```
 
-The runtime image's CMD references `/ldap/ldif/` — mount any directory containing `.ldif` files there to seed entries. Empty mount = server starts with no entries (matches legacy behavior; does NOT fall back to bundled defaults when an empty-but-present `--ldifs` arg is supplied). **The `e2e` target overrides the entrypoint** (`--entrypoint java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT}` with no LDIF arg) so the server loads the bundled `ldap-example.ldif` defaults — that's the only way `AuthenticateWithSearch jduke theduke` can find an entry to bind against without a host-side mount.
+The runtime image ships **pre-seeded**: the Dockerfile `COPY`s `src/main/resources/ldap-example.ldif` into `/ldap/ldif/`, so a bare `docker run` (default CMD `… /ldap/ldif/`) starts with the example tree (`uid=jduke`/`theduke` + Admin group). Bind-mounting a directory over `/ldap/ldif/` **replaces** the baked-in seed — every `.ldif` inside is imported; mounting an *empty* directory shadows the seed and starts with no entries (the server does NOT fall back to bundled defaults on an empty-but-present directory arg). **The `e2e` target overrides the entrypoint** (`--entrypoint java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT}` with no LDIF arg) so the server loads the JAR-bundled `ldap-example.ldif` — equivalent data, exercising the no-arg path. (Both the baked `/ldap/ldif/` seed and the JAR-bundled default come from the same `src/main/resources/ldap-example.ldif`.)
 
 ## CI (`.github/workflows/build-test-push.yml`)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,13 @@ WORKDIR /ldap
 COPY --from=build --chown=${APP_UID}:${APP_GID} \
      /workspace/target/ldap-server.jar /ldap/ldap-server.jar
 
+# Pre-seed the bundled example tree so a bare `docker run` (no mount) starts
+# WITH data (dc=ldap,dc=example: uid=jduke/theduke + an Admin group). A
+# `-v <dir>:/ldap/ldif/` bind mount shadows this directory, so custom seeds
+# still fully replace it.
+COPY --from=build --chown=${APP_UID}:${APP_GID} \
+     /workspace/src/main/resources/ldap-example.ldif /ldap/ldif/ldap-example.ldif
+
 USER ${APP_UID}
 
 EXPOSE ${APP_INTERNAL_PORT}
@@ -72,9 +79,10 @@ EXPOSE ${APP_INTERNAL_PORT}
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
     CMD nc -z "${HEALTHCHECK_HOST}" "${APP_INTERNAL_PORT}" || exit 1
 
-# Mount any directory with `.ldif` files to /ldap/ldif/ to seed the server,
-# e.g. `docker run -v ./ldif:/ldap/ldif/ ...`. An empty mount leaves the
-# server running with no entries (it does NOT fall back to bundled defaults
-# when an empty `--ldifs` arg is supplied — that's a regression from no-arg
-# invocation, but matches the legacy Dockerfile's behavior).
+# /ldap/ldif/ ships pre-seeded with ldap-example.ldif (above), so a bare
+# `docker run` starts with the example tree. Bind-mount your own directory
+# (`docker run -v ./ldif:/ldap/ldif/ ...`) to replace it with custom `.ldif`
+# files. A mount of an EMPTY directory shadows the baked-in seed and leaves the
+# server running with no entries (it does NOT fall back to bundled defaults on
+# an empty directory arg — matches legacy behavior).
 CMD java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/

--- a/README.md
+++ b/README.md
@@ -135,24 +135,23 @@ Pre-built images are published to [GHCR](https://ghcr.io) on every `v*` git tag:
 docker pull ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
 
-The default entrypoint imports every `*.ldif` under `/ldap/ldif/`, which is an **empty mount point** in the image — so a plain `docker run` with no mount starts with **no directory entries**. Two ways to seed data, both using this repo's own example tree:
-
-**1. Bundled example data (no mount).** The JAR bundles [`src/main/resources/ldap-example.ldif`](src/main/resources/ldap-example.ldif) (`dc=ldap,dc=example` with `uid=jduke` / `theduke` + an `Admin` group). Override the entrypoint to run with no LDIF argument, which falls back to that bundled default:
+The image ships **pre-seeded**: [`ldap-example.ldif`](src/main/resources/ldap-example.ldif) is baked into `/ldap/ldif/` (`dc=ldap,dc=example` with `uid=jduke` / `theduke` + an `Admin` group), so a bare `docker run` starts with the example tree:
 
 ```bash
-docker run -it --rm -p 10389:10389 --entrypoint java \
-  ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest \
-  -jar /ldap/ldap-server.jar -b 0.0.0.0 -p 10389
+docker run -it --rm -p 10389:10389 \
+  ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 # bind: uid=jduke,ou=Users,dc=ldap,dc=example / theduke
 ```
 
-**2. Mount a directory of `.ldif` files.** Every `*.ldif` inside is imported (non-`.ldif` files are ignored). Mount this repo's `src/main/resources/` to seed the same example tree, or point at your own directory:
+To seed your own entries, bind-mount a directory of `.ldif` files over `/ldap/ldif/` — this **replaces** the baked-in seed; every `*.ldif` inside is imported (non-`.ldif` files ignored). For example, mount this repo's `src/main/resources/` (same tree), or point at your own directory:
 
 ```bash
 docker run -it --rm -p 10389:10389 \
   -v "$PWD/src/main/resources:/ldap/ldif:ro" \
   ghcr.io/andriykalashnykov/ldap-server/apacheds-ad:latest
 ```
+
+(Mounting an *empty* directory shadows the baked-in seed and starts the server with no entries.)
 
 **Connecting.** The directory's built-in administrator exists regardless of how data is seeded:
 


### PR DESCRIPTION
A bare `docker run` previously started with an empty `/ldap/ldif/`. Now the Dockerfile COPYs the bundled `ldap-example.ldif` into `/ldap/ldif/`, so the default run starts with the example tree (uid=jduke/theduke + Admin). A bind mount still replaces it; an empty-dir mount shadows it. Verified locally: bare run loads uid=jduke, smoke + e2e PASS. (The image-building docker job is tag-only; PR runs mvn build + ci-pass.)