### PR TITLE
docs: propagate mermaid-lint + image pre-seed/signing across all docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Multi-stage `Dockerfile`, **builds from source** (does not download a released J
 - **Builder**: `maven:3.9-eclipse-temurin-25` runs `mvn -B -DskipTests clean package` with a BuildKit cache mount on `~/.m2`.
 - **Runtime**: `eclipse-temurin:25-jre-alpine`. Non-root user UID/GID 10001 (busybox `addgroup`/`adduser`, no home, `/sbin/nologin`), owns `/ldap`. No `apk add` in the runtime layer.
 - **HEALTHCHECK**: `nc -z ${HEALTHCHECK_HOST} ${APP_INTERNAL_PORT}` (busybox netcat) — probes the LDAP TCP listener since ApacheDS exposes no HTTP endpoint. The flag *timings* are literal because Docker's parser does not expand ARG/ENV in those slots; the CMD's `${VAR}` honor `docker run -e ...` overrides.
-- **CMD** (shell form): `java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/`. Mount a directory of `.ldif` files into `/ldap/ldif/` to seed entries.
+- **CMD** (shell form): `java -jar /ldap/ldap-server.jar -b 0.0.0.0 -p ${APP_INTERNAL_PORT} /ldap/ldif/`. The image is **pre-seeded** — the Dockerfile `COPY`s `ldap-example.ldif` into `/ldap/ldif/`, so a bare `docker run` starts with the example tree; bind-mount a directory of `.ldif` files over `/ldap/ldif/` to replace it.
+- **Supply chain**: tagged images are cosign keyless-signed (OIDC) with an SPDX SBOM attestation; `provenance`/`sbom` stay false on the index (keeps the GHCR OS/Arch tab clean).
 
 Container workflows: `make image-build`, `make image-smoke-test`, `make image-run`, `make e2e`. The `e2e` target overrides the entrypoint with no LDIF arg so the server loads the bundled `ldap-example.ldif` defaults.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ java -jar ./target/ldap-server.jar ./target/classes/ # run with bundled LDIFs as
 java -jar ./target/ldap-server.jar --help            # full CLI flag list (includes --admin-password, --ssl-*)
 ```
 
-`make ci` chains `deps → check-java-alignment → check-maven-alignment → lint → test → package`. The two alignment guards fail fast when the Java major in `.mise.toml` drifts from the Dockerfile `FROM` lines, or when the Maven minor drifts from the build-stage tag — silent toolchain desync is otherwise a recurring foot-gun on Renovate split-PR days. Both guards are mutation-tested (proven to go RED on intentional desync).
+`make ci` chains `deps → check-java-alignment → check-maven-alignment → lint → test → package`. The two alignment guards fail fast when the Java major in `.mise.toml` drifts from the Dockerfile `FROM` lines, or when the Maven minor drifts from the build-stage tag — silent toolchain desync is otherwise a recurring foot-gun on Renovate split-PR days. Both guards are mutation-tested (proven to go RED on intentional desync). `make lint` also runs **`mermaid-lint`** — validates the README C4 hero diagram via `minlag/mermaid-cli` (`MERMAID_CLI_VERSION` pinned + Renovate-tracked through a Makefile customManager); it skips under `act` (docker-in-docker bind-mount mismatch) and runs on real CI.
 
 `pom.xml` sets `maven.compiler.source=25` (matches the Dockerfile runtime `eclipse-temurin:25-jre`). AM27 itself ships bytecode 52 (Java 8) but our application can target whatever runtime we deploy on — the dep's floor does not constrain the consumer's target. The `release` profile that enforced `[1.8,1.9)` was removed in this fork; re-add it from upstream if Maven Central publishing is ever wanted.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ Run `make help` to see every target with its description.
 | `make test` | Run JUnit tests |
 | `make package` | Build the shaded runnable JAR at `target/ldap-server.jar` |
 | `make run-jar` | Run the packaged JAR with the bundled LDIF |
-| `make lint` | Validate `pom.xml` + shell-script executable-bit guard |
+| `make lint` | Validate `pom.xml` + shell-script executable-bit guard + `mermaid-lint` |
+| `make mermaid-lint` | Validate README Mermaid diagrams via `minlag/mermaid-cli` (skipped under act) |
 | `make cve-check` | OWASP dependency-check (transitive deps; ~2 GB NVD download on first run) |
 | `make clean` | Remove Maven build artifacts |
 


### PR DESCRIPTION
Closes 3 doc-consistency gaps from this session's feature additions: README Make Targets gains the mermaid-lint row (/readme #16), CLAUDE.md mentions mermaid-lint in the make ci/lint description (/claude #8), AGENTS.md Docker notes pre-seed + cosign signing. CLAUDE.md change → code=true → build re-runs mermaid-lint on real CI.