### PR TITLE
fix(deps): resolve CVE-2026-35563 (8.8) — pin Apache Directory LDAP API to 2.1.8

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -25,4 +25,20 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/.*@2\.0\.0\.AM27$</packageUrl>
         <cve>CVE-2010-1151</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            False positive. CVE-2026-35563 (8.8) is a flaw in the Apache Directory
+            *LDAP API* client (cpe:apache:directory_ldap_api) — the TLS layer did
+            not verify the server certificate's hostname; fixed in api 2.1.8. The
+            real api-* dependency is pinned to the fixed 2.1.8 in pom.xml, but
+            dependency-check additionally CPE-matches the ApacheDS *server* modules
+            (org.apache.directory.server:*@2.0.0.AM27 — e.g. apacheds-interceptors-
+            admin) to the directory_ldap_api CPE at version 2.0.0.am27. Those server
+            interceptor/core modules are not the vulnerable LDAP-client TLS code and
+            do not ship a fixed AM-line release. Pinned to 2.0.0.AM27; re-evaluate
+            (delete or re-range) when bumping ApacheDS past AM27.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/.*@2\.0\.0\.AM27$</packageUrl>
+        <cve>CVE-2026-35563</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.apache.ds>2.0.0.AM27</version.org.apache.ds>
+        <!-- CVE override: pins the Apache Directory LDAP API above AM27's
+             transitive 2.1.5 (see api-parent BOM import note below). -->
+        <version.org.apache.directory.api>2.1.8</version.org.apache.directory.api>
         <version.junit>6.1.0</version.junit>
         <!-- CVE override: AM27 pulls bc*-jdk15on 1.70 transitively (CVE-2024-29857
              7.5, CVE-2024-34447 7.7). The jdk15on line ended at 1.70; the fix is
@@ -112,6 +115,21 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${version.junit}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <!-- CVE override: AM27's apacheds-parent manages the Apache Directory
+                 LDAP API at 2.1.5 (CVE-2026-35563, 8.8 — the LDAP *client* TLS
+                 layer does not verify the server certificate's hostname, enabling
+                 MITM; fixed in 2.1.8, released 2026-05-31). Importing api-parent
+                 2.1.8 BEFORE apacheds-parent overrides all 16 api-* modules to the
+                 fixed line (earlier BOM import wins). Patch bump within the 2.1.x
+                 minor — binary-compatible with AM27. Removable (revert to AM27's
+                 transitive) once ApacheDS ships a release on api >= 2.1.8. -->
+            <dependency>
+                <groupId>org.apache.directory.api</groupId>
+                <artifactId>api-parent</artifactId>
+                <version>${version.org.apache.directory.api}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Root cause

The weekly `cve-check` cron (CI run [27123834946](https://github.com/AndriyKalashnykov/ldap-server/actions/runs/27123834946), 2026-06-08) failed — the only failing CI/CD run. Cause: NVD published **CVE-2026-35563 (CVSS 8.8)** against the Apache Directory LDAP API. The LDAP **client** TLS layer did not verify the server certificate's hostname (MITM), fixed in **api 2.1.8** (released 2026-05-31). ApacheDS `2.0.0.AM27` pulls the `api-*` modules transitively at the vulnerable **2.1.5**.

This is the classic "scanner vuln-DB drifted and reddened an unchanged dependency on `master`" pattern — nothing in the repo changed; the CVE was newly disclosed.

The OWASP dependency-check gate (`failBuildOnCVSS=7`) flagged three artifacts ≥7.0, all CVE-2026-35563(8.8):
- `api-i18n-2.1.5.jar`
- `api-ldap-codec-core-2.1.5.jar`
- `apacheds-interceptors-admin-2.0.0.AM27.jar` — a **server** interceptor module wrongly CPE-matched to the `directory_ldap_api` product

## Fix

1. **Pin the api to the fixed line.** Import `org.apache.directory.api:api-parent:2.1.8` as a BOM **before** `apacheds-parent` (earlier import wins for conflicting managed versions), overriding all 16 `api-*` modules from 2.1.5 → 2.1.8. Patch bump within the `2.1.x` minor — binary-compatible with AM27.
2. **Suppress the CPE false positive** on the ApacheDS *server* modules (`org.apache.directory.server:*@2.0.0.AM27`). These are not the vulnerable LDAP-client TLS code and ship no fixed AM-line release; dependency-check matches them to the `directory_ldap_api` CPE in error. Scoped + documented with an AM27 re-evaluation trigger, mirroring the existing CVE-2010-1151 suppression.

## Verification

- `mvn dependency:tree` → all 16 `api-*` modules now resolve to **2.1.8**.
- `make ci` → **green** (Java/Maven alignment guards + lint + mermaid-lint + **8/8 tests** + package). `StartTlsTest` exercises the TLS stack and passes, confirming AM27 ↔ api 2.1.8 compatibility.
- `make cve-check` → **BUILD SUCCESS** (NVD + Sonatype OSS Index analyzers both ran); CVE-2026-35563 no longer fails the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)