### PR TITLE
fix(ci): SBOM step must not upload a release asset

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -388,6 +388,16 @@ jobs:
           image: ${{ steps.img.outputs.ref }}@${{ steps.push.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          # The SBOM is attached via `cosign attest` to the IMAGE (next step),
+          # NOT as a GitHub Release asset. anchore/sbom-action defaults
+          # upload-release-assets:true, which — now that per-version releases
+          # (v1.2.5+) create a release MATCHING the pushed tag — tries to upload
+          # the SBOM as a release asset and fails with "Resource not accessible
+          # by integration" (the docker job has contents:read, not write).
+          # Disable it: keeps the job's permissions minimal and the SBOM stays
+          # an image attestation only. (Pre-v1.2.5 this never fired because the
+          # release was tagged `latest`, not the version tag.)
+          upload-release-assets: false
 
       - name: Attest SBOM (keyless OIDC)
         env:


### PR DESCRIPTION
**Root cause:** `anchore/sbom-action` defaults `upload-release-assets: true`. The per-version release change (#50) made the `release` job create a GitHub Release matching the pushed tag (`v1.2.5`), so the SBOM step tried to upload a release asset — needs `contents: write`, but the `docker` job has `contents: read` → `Resource not accessible by integration` (v1.2.5 docker job red). Pre-#50 it never fired (release was tagged `latest`, not the version tag).

**Fix:** `upload-release-assets: false`. The SBOM is attached via `cosign attest` to the image by design (not a release asset); this keeps the docker job's permissions minimal. The v1.2.5 image **did publish + was cosign-signed** (push + sign run before the SBOM step) — only the SBOM attestation was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)